### PR TITLE
Feat: 사장님 - 공고상세 - 타이틀 UI 컴포넌트 구현

### DIFF
--- a/components/shopNoticePage/contentsTitle/Category.tsx
+++ b/components/shopNoticePage/contentsTitle/Category.tsx
@@ -1,0 +1,8 @@
+type Props = {
+  category: "한식" | "중식" | "일식" | "양식" | "분식" | "카페" | "편의점" | "기타";
+  className: string;
+};
+
+export default function Category({ category, className }: Props) {
+  return <small className={className}>{category}</small>;
+}

--- a/components/shopNoticePage/contentsTitle/ContentsTitle.tsx
+++ b/components/shopNoticePage/contentsTitle/ContentsTitle.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import Category from "./Category";
+import Title from "./Title";
+
+type Props = {
+  className: string;
+  children: React.ReactNode;
+};
+
+export default function ContentsTitle({ className, children }: Props) {
+  return <div className={className}>{children}</div>;
+}
+
+ContentsTitle.Category = Category;
+ContentsTitle.Title = Title;

--- a/components/shopNoticePage/contentsTitle/Title.tsx
+++ b/components/shopNoticePage/contentsTitle/Title.tsx
@@ -1,8 +1,8 @@
 type Props = {
-  shopName: string;
+  title: string;
   className: string;
 };
 
-export default function Title({ shopName, className }: Props) {
-  return <h2 className={className}>{shopName}</h2>;
+export default function Title({ title, className }: Props) {
+  return <h2 className={className}>{title}</h2>;
 }

--- a/components/shopNoticePage/contentsTitle/Title.tsx
+++ b/components/shopNoticePage/contentsTitle/Title.tsx
@@ -1,0 +1,8 @@
+type Props = {
+  shopName: string;
+  className: string;
+};
+
+export default function Title({ shopName, className }: Props) {
+  return <h2 className={className}>{shopName}</h2>;
+}


### PR DESCRIPTION
## 주요 구현 사항 ✨

- 사장님의 공고 상세 페이지의 "식당 이름" "신청자 목록" 과 같은 타이틀 컴포넌트를 구현하였습니다.

## 스크린샷 🎨

- 식당 제목으로 사용
<img width="51" alt="스크린샷 2024-01-26 오후 7 25 31" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/a880f456-2617-478b-baa4-6a9a20ded8a2">

- 신청자 목록 제목으로 사용
<p></p>
<img width="136" alt="스크린샷 2024-01-26 오후 7 26 02" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/b503b4fd-2e26-42ff-b557-55af4cf84258">

## 구체적 구현 사항 설명 📃

- Category 컴포넌트 : 가게의 api 정보 중 category 정보를 prop으로 받아와서 보여줍니다. ex) 일식
- Title 컴포넌트: 보여주고 싶은 제목을 title이라는 prop으로 받아와 보여줍니다.
- ContentTitle 컴포넌트 ->에 위의 두 컴포넌트를 컴파운드 패턴으로 연결시켰습니다. 
- css의 경우 각각의 컴포넌트에서 적용하는 것이 아니라, className을 prop으로 받아 사용하는 곳에서 정의합니다.

## 실사용 예시
```
import ContentsTitle from "@/components/shopNoticePage/contentsTitle/ContentsTitle";
import classNames from "classnames/bind";
import styles from "@/styles/Notice.module.scss";
const cn = classNames.bind(styles);

export default function NoticePage() {
  return (
      <ContentsTitle className={cn("shopTitleContainer")}>
        <ContentsTitle.Category category="일식" className={cn("shopCategory")} />
        <ContentsTitle.Title shopName="리애" className={cn("shopName")} />
      </ContentsTitle>
  );
}
```

## 논의사항 🤔

-

