### PR TITLE
Feat: 사장님-가게정보등록 form UI 구현

### DIFF
--- a/components/register/shopInfo/shopInfoForm/FileInput.tsx
+++ b/components/register/shopInfo/shopInfoForm/FileInput.tsx
@@ -1,0 +1,23 @@
+import Image from "next/image";
+import CarmeraIcon from "@/public/images/camera.svg";
+import classNames from "classnames/bind";
+import styles from "@/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss";
+
+const cn = classNames.bind(styles);
+
+export default function FileInput() {
+  return (
+    <div className={cn("inputBox", "file")}>
+      <p className={cn("title")}>가게 이미지</p>
+      <div className={cn("wrap")}>
+        <label htmlFor="file" className={cn("label")}>
+          <div className={cn("cameraImage")}>
+            <Image fill src={CarmeraIcon} alt="카메라 아이콘" object-fit="cover" />
+          </div>
+          이미지 추가하기
+        </label>
+      </div>
+      <input type="file" id="file" name="file" />
+    </div>
+  );
+}

--- a/components/register/shopInfo/shopInfoForm/Input.tsx
+++ b/components/register/shopInfo/shopInfoForm/Input.tsx
@@ -4,13 +4,13 @@ import styles from "@/components/register/shopInfo/shopInfoForm/shopInfoForm.mod
 
 const cn = classNames.bind(styles);
 
-export default function Input(props: Props) {
+export default function Input({ label, title, input }: Props) {
   return (
     <div className={cn("inputBox")}>
-      <label htmlFor={props.for} className={cn("title")}>
-        {props.title}*
+      <label htmlFor={label} className={cn("title")}>
+        {title}*
       </label>
-      <input {...props.input} placeholder="입력" />
+      <input {...input} placeholder="입력" />
     </div>
   );
 }

--- a/components/register/shopInfo/shopInfoForm/Input.tsx
+++ b/components/register/shopInfo/shopInfoForm/Input.tsx
@@ -1,0 +1,16 @@
+import { Props } from "@/components/register/shopInfo/shopInfoForm/type";
+import classNames from "classnames/bind";
+import styles from "@/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss";
+
+const cn = classNames.bind(styles);
+
+export default function Input(props: Props) {
+  return (
+    <div className={cn("inputBox")}>
+      <label htmlFor={props.for} className={cn("title")}>
+        {props.title}*
+      </label>
+      <input {...props.input} placeholder="입력" />
+    </div>
+  );
+}

--- a/components/register/shopInfo/shopInfoForm/SelectBox.tsx
+++ b/components/register/shopInfo/shopInfoForm/SelectBox.tsx
@@ -5,12 +5,12 @@ import styles from "@/components/register/shopInfo/shopInfoForm/shopInfoForm.mod
 
 const cn = classNames.bind(styles);
 
-export default function Input(props: Props) {
-  const items = props.item || [];
+export default function Input({ title, item } : Props) {
+  const items = item || [];
 
   return (
     <div className={cn("inputBox")}>
-      <p className={cn("title")}>{props.title}</p>
+      <p className={cn("title")}>{title}</p>
       <label htmlFor="shopName" className={cn("option")}>
         선택<span className={cn("dropdownOpen")}>열기</span>
       </label>

--- a/components/register/shopInfo/shopInfoForm/SelectBox.tsx
+++ b/components/register/shopInfo/shopInfoForm/SelectBox.tsx
@@ -1,0 +1,24 @@
+import { Props } from "@/components/register/shopInfo/shopInfoForm/type";
+import { Item } from "@/components/register/shopInfo/shopInfoForm/type";
+import classNames from "classnames/bind";
+import styles from "@/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss";
+
+const cn = classNames.bind(styles);
+
+export default function Input(props: Props) {
+  const items = props.item || [];
+
+  return (
+    <div className={cn("inputBox")}>
+      <p className={cn("title")}>{props.title}</p>
+      <label htmlFor="shopName" className={cn("option")}>
+        선택<span className={cn("dropdownOpen")}>열기</span>
+      </label>
+      <ul>
+        {items.map((item: Item) => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/register/shopInfo/shopInfoForm/TextInput.tsx
+++ b/components/register/shopInfo/shopInfoForm/TextInput.tsx
@@ -4,15 +4,15 @@ import styles from "@/components/register/shopInfo/shopInfoForm/shopInfoForm.mod
 
 const cn = classNames.bind(styles);
 
-export default function TextInput(props: Props) {
+export default function TextInput({ label, title, input, text}: Props) {
   return (
     <div className={cn("inputBox")}>
-      <label htmlFor={props.for} className={cn("title")}>
-        {props.title}*
+      <label htmlFor={label} className={cn("title")}>
+        {title}*
       </label>
       <div className={cn("wrap")}>
-        <input {...props.input} placeholder="입력" />
-        <span className={cn("won")}>{props.text}</span>
+        <input {...input} placeholder="입력" />
+        <span className={cn("won")}>{text}</span>
       </div>
     </div>
   );

--- a/components/register/shopInfo/shopInfoForm/TextInput.tsx
+++ b/components/register/shopInfo/shopInfoForm/TextInput.tsx
@@ -1,0 +1,19 @@
+import { Props } from "@/components/register/shopInfo/shopInfoForm/type";
+import classNames from "classnames/bind";
+import styles from "@/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss";
+
+const cn = classNames.bind(styles);
+
+export default function TextInput(props: Props) {
+  return (
+    <div className={cn("inputBox")}>
+      <label htmlFor={props.for} className={cn("title")}>
+        {props.title}*
+      </label>
+      <div className={cn("wrap")}>
+        <input {...props.input} placeholder="입력" />
+        <span className={cn("won")}>{props.text}</span>
+      </div>
+    </div>
+  );
+}

--- a/components/register/shopInfo/shopInfoForm/Textarea.tsx
+++ b/components/register/shopInfo/shopInfoForm/Textarea.tsx
@@ -4,13 +4,13 @@ import styles from "@/components/register/shopInfo/shopInfoForm/shopInfoForm.mod
 
 const cn = classNames.bind(styles);
 
-export default function Textarea(props: Props) {
+export default function Textarea({ label, title, textarea }: Props) {
   return (
     <div className={cn("inputBox")}>
-      <label htmlFor={props.for} className={cn("title")}>
-        {props.title}
+      <label htmlFor={label} className={cn("title")}>
+        {title}
       </label>
-      <textarea {...props.textarea} className={cn("desc")} placeholder="입력"></textarea>
+      <textarea {...textarea} className={cn("desc")} placeholder="입력"></textarea>
     </div>
   );
 }

--- a/components/register/shopInfo/shopInfoForm/Textarea.tsx
+++ b/components/register/shopInfo/shopInfoForm/Textarea.tsx
@@ -1,0 +1,16 @@
+import { Props } from "@/components/register/shopInfo/shopInfoForm/type";
+import classNames from "classnames/bind";
+import styles from "@/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss";
+
+const cn = classNames.bind(styles);
+
+export default function Textarea(props: Props) {
+  return (
+    <div className={cn("inputBox")}>
+      <label htmlFor={props.for} className={cn("title")}>
+        {props.title}
+      </label>
+      <textarea {...props.textarea} className={cn("desc")} placeholder="입력"></textarea>
+    </div>
+  );
+}

--- a/components/register/shopInfo/shopInfoForm/Textarea.tsx
+++ b/components/register/shopInfo/shopInfoForm/Textarea.tsx
@@ -1,12 +1,12 @@
 import { Props } from "@/components/register/shopInfo/shopInfoForm/type";
 import classNames from "classnames/bind";
-import styles from "@/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss";
+import styles from "@/components/register/shopInfo/shopInfoForm/ShopInfoForm.module.scss";
 
 const cn = classNames.bind(styles);
 
 export default function Textarea({ label, title, textarea }: Props) {
   return (
-    <div className={cn("inputBox")}>
+    <div className={cn("inputBox", "textarea")}>
       <label htmlFor={label} className={cn("title")}>
         {title}
       </label>

--- a/components/register/shopInfo/shopInfoForm/constants.ts
+++ b/components/register/shopInfo/shopInfoForm/constants.ts
@@ -1,0 +1,139 @@
+export const FOOD_CATEGORY = [
+  {
+    id: "korean",
+    name: "한식",
+  },
+  {
+    id: "chinese",
+    name: "중식",
+  },
+  {
+    id: "japanese",
+    name: "일식",
+  },
+  {
+    id: "western",
+    name: "양식",
+  },
+  {
+    id: "snackBar",
+    name: "분식",
+  },
+  {
+    id: "cafe",
+    name: "카페",
+  },
+  {
+    id: "convenienceStore",
+    name: "편의점",
+  },
+  {
+    id: "etc",
+    name: "기타",
+  },
+];
+
+export const ADDRESS = [
+  {
+    id: "jongnoGu",
+    name: "서울시 종로구",
+  },
+  {
+    id: "jungGu",
+    name: "서울시 중구",
+  },
+  {
+    id: "yongsanGu",
+    name: "서울시 용산구",
+  },
+  {
+    id: "seongdongGu",
+    name: "서울시 성동구",
+  },
+  {
+    id: "gwangjinGu",
+    name: "서울시 광진구",
+  },
+  {
+    id: "dongdaemunGu",
+    name: "서울시 동대문구",
+  },
+  {
+    id: "jungnangGu",
+    name: "서울시 중랑구",
+  },
+  {
+    id: "seongbukGu",
+    name: "서울시 성북구",
+  },
+  {
+    id: "gangbukGu",
+    name: "서울시 강북구",
+  },
+  {
+    id: "dobongGu",
+    name: "서울시 도봉구",
+  },
+  {
+    id: "nowonGu",
+    name: "서울시 노원구",
+  },
+  {
+    id: "eunpyeongGu",
+    name: "서울시 은평구",
+  },
+  {
+    id: "seodaemunGu",
+    name: "서울시 서대문구",
+  },
+  {
+    id: "mapoGu",
+    name: "서울시 마포구",
+  },
+  {
+    id: "yangcheonGu",
+    name: "서울시 양천구",
+  },
+  {
+    id: "gangseoGu",
+    name: "서울시 강서구",
+  },
+  {
+    id: "guroGu",
+    name: "서울시 구로구",
+  },
+  {
+    id: "geumcheonGu",
+    name: "서울시 금천구",
+  },
+  {
+    id: "yeongdeungpoGu",
+    name: "서울시 영등포구",
+  },
+  {
+    id: "dongjakGu",
+    name: "서울시 동작구",
+  },
+  {
+    id: "gwanakGu",
+    name: "서울시 관악구",
+  },
+  {
+    id: "seochoGu",
+    name: "서울시 서초구",
+  },
+  {
+    id: "gangnamGu",
+    name: "서울시 강남구",
+  },
+  {
+    id: "songpaGu",
+    name: "서울시 송파구",
+  },
+  {
+    id: "gangdongGu",
+    name: "서울시 강동구",
+  },
+];
+
+

--- a/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss
+++ b/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss
@@ -4,6 +4,11 @@
   color: $color-gray-40;
 }
 
+.container {
+  max-width: 964px;
+  margin: 0 auto;
+}
+
 .inputWrap {
   display: flex;
   flex-wrap: wrap;

--- a/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss
+++ b/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss
@@ -171,3 +171,7 @@
     display: none;
   }
 }
+
+.inputBox.textarea {
+  width: 100%;
+}

--- a/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss
+++ b/components/register/shopInfo/shopInfoForm/shopInfoForm.module.scss
@@ -1,0 +1,168 @@
+@use "@/styles/variables.scss" as *;
+
+@mixin placeholder {
+  color: $color-gray-40;
+}
+
+.inputWrap {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.inputBox {
+  width: calc(50% - 20px);
+
+  &:nth-child(n + 3) {
+    margin: 2.4rem 0 0;
+  }
+
+  .title {
+    display: block;
+    margin-bottom: 0.8rem;
+    color: $color-black;
+    line-height: 2.6rem;
+  }
+
+  input[type="text"] {
+    width: 100%;
+    padding: 1.6rem 2rem;
+    outline: none;
+    line-height: 2.6rem;
+    color: $color-black;
+    border-radius: 0.6rem;
+    border: 1px solid $color-gray-30;
+
+    &::placeholder {
+      @include placeholder();
+    }
+  }
+
+  .wrap {
+    position: relative;
+
+    .won {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      right: 2rem;
+
+      line-height: 2.6rem;
+      color: $color-black;
+    }
+  }
+
+  .option {
+    display: block;
+    position: relative;
+    padding: 1.6rem 2rem;
+    line-height: 2.6rem;
+    color: $color-gray-40;
+    border-radius: 0.6rem;
+    border: 1px solid $color-gray-30;
+    cursor: pointer;
+
+    .dropdownOpen {
+      display: block;
+      position: absolute;
+      top: 50%;
+      right: 2rem;
+      transform: translateY(-50%);
+      width: 1.6rem;
+      height: 1.6rem;
+      background: url("~/public/images/dropdown_open.svg") no-repeat center;
+      overflow: hidden;
+      text-indent: 100%;
+      white-space: nowrap;
+    }
+  }
+
+  ul {
+    list-style-type: none;
+    margin: 0.8rem 0 0;
+    padding: 0;
+    height: 23rem;
+    border-radius: 0.6rem;
+    border: 1px solid $color-gray-20;
+    overflow-y: scroll;
+    box-shadow: 0px 4px 25px 0px #0000001a;
+
+    &::-webkit-scrollbar {
+      width: 0.4rem;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: 4rem;
+      background-color: $color-gray-50;
+    }
+
+    li {
+      padding: 1.2rem 0;
+      font-size: 1.4rem;
+      line-height: 2.2rem;
+      color: $color-black;
+      text-align: center;
+      border-bottom: 1px solid $color-gray-20;
+      cursor: pointer;
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+  }
+
+  .desc {
+    resize: none;
+    outline: none;
+    width: 100%;
+    height: 15.3rem;
+    padding: 1.6rem 2rem;
+    border-radius: 0.6rem;
+    border: 1px solid $color-gray-30;
+    line-height: 2.6rem;
+    color: $color-black;
+
+    &::placeholder {
+      @include placeholder();
+    }
+  }
+}
+
+.inputBox.file {
+  position: relative;
+  margin: 2.4rem 0 0;
+
+  .wrap {
+    width: 48.3rem;
+    height: 27.6rem;
+    border-radius: 0.6rem;
+    border: 1px solid $color-gray-30;
+    background-color: $color-gray-10;
+    cursor: pointer;
+
+    .label {
+      display: block;
+      width: 100%;
+      height: 100%;
+      padding: calc(50% - 15rem) 0 0;
+      font-weight: 700;
+      line-height: 2rem;
+      color: $color-gray-40;
+      cursor: pointer;
+      text-align: center;
+    }
+
+    .cameraImage {
+      position: relative;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 3.2rem;
+      height: 3.2rem;
+      margin: 0 0 1.1rem;
+    }
+  }
+
+  input[type="file"] {
+    display: none;
+  }
+}

--- a/components/register/shopInfo/shopInfoForm/shopInfoForm.tsx
+++ b/components/register/shopInfo/shopInfoForm/shopInfoForm.tsx
@@ -15,7 +15,7 @@ export default function ShopInfoForm() {
       <form>
         <div className={cn("inputWrap")}>
           <Input
-            for="shopName"
+            label="shopName"
             title="가게 이름"
             input={{
               type: "text",
@@ -26,7 +26,7 @@ export default function ShopInfoForm() {
           <SelectBox title="분류*" item={FOOD_CATEGORY} />
           <SelectBox title="주소*" item={ADDRESS} />
           <Input
-            for="detailAddress"
+            label="detailAddress"
             title="상세 주소"
             input={{
               type: "text",
@@ -35,7 +35,7 @@ export default function ShopInfoForm() {
             }}
           />
           <TextInput
-            for="wage"
+            label="wage"
             title="기본 시급"
             text="원"
             input={{
@@ -47,7 +47,7 @@ export default function ShopInfoForm() {
         </div>
         <FileInput />
         <Textarea
-          for="desc"
+          label="desc"
           title="가게 설명"
           textarea={{
             id: "desc",

--- a/components/register/shopInfo/shopInfoForm/shopInfoForm.tsx
+++ b/components/register/shopInfo/shopInfoForm/shopInfoForm.tsx
@@ -1,0 +1,60 @@
+import Input from "@/components/register/shopInfo/shopInfoForm/Input";
+import SelectBox from "@/components/register/shopInfo/shopInfoForm/SelectBox";
+import Textarea from "@/components/register/shopInfo/shopInfoForm/Textarea";
+import FileInput from "@/components/register/shopInfo/shopInfoForm/FileInput";
+import TextInput from "@/components/register/shopInfo/shopInfoForm/TextInput";
+import { FOOD_CATEGORY, ADDRESS } from "@/components/register/shopInfo/shopInfoForm/constants";
+import classNames from "classnames/bind";
+import styles from "@/components/register/shopInfo/shopInfoForm/ShopInfoForm.module.scss";
+
+const cn = classNames.bind(styles);
+
+export default function ShopInfoForm() {
+  return (
+    <div className={cn("container")}>
+      <form>
+        <div className={cn("inputWrap")}>
+          <Input
+            for="shopName"
+            title="가게 이름"
+            input={{
+              type: "text",
+              id: "shopName",
+              name: "shopName",
+            }}
+          />
+          <SelectBox title="분류*" item={FOOD_CATEGORY} />
+          <SelectBox title="주소*" item={ADDRESS} />
+          <Input
+            for="detailAddress"
+            title="상세 주소"
+            input={{
+              type: "text",
+              id: "detailAddress",
+              name: "detailAddress",
+            }}
+          />
+          <TextInput
+            for="wage"
+            title="기본 시급"
+            text="원"
+            input={{
+              type: "text",
+              id: "wage",
+              name: "wage",
+            }}
+          />
+        </div>
+        <FileInput />
+        <Textarea
+          for="desc"
+          title="가게 설명"
+          textarea={{
+            id: "desc",
+            name: "desc",
+          }}
+        />
+      </form>
+    </div>
+  );
+}

--- a/components/register/shopInfo/shopInfoForm/type.ts
+++ b/components/register/shopInfo/shopInfoForm/type.ts
@@ -1,0 +1,25 @@
+export interface Props {
+  for?: string;
+  id?: string;
+  title?: string;
+  input?: {
+    type: string;
+    id: string;
+    name: string;
+  };
+  text?: string;
+  item?: {
+    id: string;
+    name: string;
+  } [];
+  textarea?: {
+    id: string;
+    name: string;
+  }
+}
+
+export interface Item {
+  id: string;
+  name: string;
+}
+

--- a/components/register/shopInfo/shopInfoForm/type.ts
+++ b/components/register/shopInfo/shopInfoForm/type.ts
@@ -1,6 +1,5 @@
 export interface Props {
-  for?: string;
-  id?: string;
+  label?: string;
   title?: string;
   input?: {
     type: string;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,10 @@
 // 공고 리스트 페이지
-
+import ShopInfoForm from "@/components/register/shopInfo/shopInfoForm/shopInfoForm";
 export default function Home() {
   return (
     <>
       <main>메인페이지</main>
+      <ShopInfoForm />
     </>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,9 @@
 // 공고 리스트 페이지
-import ShopInfoForm from "@/components/register/shopInfo/shopInfoForm/shopInfoForm";
+
 export default function Home() {
   return (
     <>
       <main>메인페이지</main>
-      <ShopInfoForm />
     </>
   );
 }


### PR DESCRIPTION
## 주요 구현 사항 ✨

- issue: #2 
- form에 들어가는 여러가지 인풋의 UI 구현

## 스크린샷 🎨

![스크린샷 2024-01-27 152053](https://github.com/sprintPart3Team4/the-julge/assets/94034865/4ccaadd8-c442-4a57-9a7b-facaed58027b)
![스크린샷 2024-01-27 152121](https://github.com/sprintPart3Team4/the-julge/assets/94034865/6c416a22-0a9c-402b-a49c-02207b49f74a)
![스크린샷 2024-01-27 154956](https://github.com/sprintPart3Team4/the-julge/assets/94034865/95a1d2fb-a142-44b9-b166-fa408274697d)


## 구체적 구현 사항 설명 📃

- 재사용성을 고려하여 input 종류별로 컴포넌트를 만들어 ShopInfoForm에 합쳤습니다
- Input 컴포넌트: text 타입의 기본 인풋
- SelectBox 컴포넌트: 목록을 선택할 수 있는 셀렉트박스
- FileInput 컴포넌트: 이미지 첨부 하는 인풋
- TextInput 컴포넌트:  text 타입의 기본 인풋에 글자 '원'을 추가한 인풋
- Textarea 컴포넌트: 설명을 입력할 수 있는 textarea

## 논의사항 🤔

-

