### PR TITLE
Feat: 사장님/공고상세 - 공고 내용 보여주는 컴포넌트 UI 구현

### DIFF
--- a/components/shopNoticePage/noticeContents/Address.tsx
+++ b/components/shopNoticePage/noticeContents/Address.tsx
@@ -1,0 +1,19 @@
+import Image from "next/image";
+import LocationActive from "@/public/images/location.svg";
+import LocationInactive from "@/public/images/location_grey.svg";
+
+type Props = {
+  address: string;
+  className: string;
+  isClosed?: boolean;
+};
+
+export default function Address({ address, className, isClosed = false }: Props) {
+  const ImageSrc = isClosed ? LocationInactive : LocationActive;
+  return (
+    <div className={className}>
+      <Image src={ImageSrc} alt="위치를 나타내기 위한 아이콘" width={20} height={20} />
+      {address}
+    </div>
+  );
+}

--- a/components/shopNoticePage/noticeContents/HourlyPay.tsx
+++ b/components/shopNoticePage/noticeContents/HourlyPay.tsx
@@ -1,0 +1,8 @@
+type Props = {
+  hourlypay: number;
+  className: string;
+};
+
+export default function HourlyPay({ hourlypay, className }: Props) {
+  return <span className={className}>{hourlypay}원</span>;
+}

--- a/components/shopNoticePage/noticeContents/HourlyPayBadge.tsx
+++ b/components/shopNoticePage/noticeContents/HourlyPayBadge.tsx
@@ -1,0 +1,25 @@
+import Image from "next/image";
+import ArrowUp from "@/public/images/arrow-up-bold.svg";
+
+type Props = {
+  hourlyPay: number;
+  originalHourlyPay: number;
+  className: string;
+  iconClassName: string;
+};
+
+export default function HourlyPayBadge({ hourlyPay, originalHourlyPay, className, iconClassName }: Props) {
+  const percentage = (hourlyPay / originalHourlyPay) * 100;
+  return (
+    <span className={className}>
+      기존 시급보다 {percentage}%
+      <Image
+        className={iconClassName}
+        src={ArrowUp}
+        alt="기존 시급보다 높은 시급이라는 걸 표시하기 위해 위를 가리키는 화살표"
+        width={20}
+        height={20}
+      />
+    </span>
+  );
+}

--- a/components/shopNoticePage/noticeContents/Panel.tsx
+++ b/components/shopNoticePage/noticeContents/Panel.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import Thumbnail from "./Thumbnail";
+import HourlyPay from "./HourlyPay";
+import HourlyPayBadge from "./HourlyPayBadge";
+import WorkHour from "./WorkHour";
+import Address from "./Address";
+import ShopDescription from "./ShopDescription";
+
+type Props = {
+  className: string;
+  children: React.ReactNode;
+};
+
+export default function Panel({ className, children }: Props) {
+  return <div className={className}>{children}</div>;
+}
+
+Panel.Thumbnail = Thumbnail;
+// 이슈넘버 28번 머지하고 나면, title 컴포넌트도 여기에 컴파운드 시키기
+Panel.HourlyPay = HourlyPay;
+Panel.HourlyPayBadge = HourlyPayBadge;
+Panel.WorkHour = WorkHour;
+Panel.Address = Address;
+Panel.shopDescription = ShopDescription;

--- a/components/shopNoticePage/noticeContents/ShopDescription.tsx
+++ b/components/shopNoticePage/noticeContents/ShopDescription.tsx
@@ -1,0 +1,8 @@
+type Props = {
+  shopDescription: string;
+  className: string;
+};
+
+export default function ShopDescription({ shopDescription, className }: Props) {
+  return <p className={className}>{shopDescription}</p>;
+}

--- a/components/shopNoticePage/noticeContents/Thumbnail.tsx
+++ b/components/shopNoticePage/noticeContents/Thumbnail.tsx
@@ -1,0 +1,14 @@
+import { StaticImport } from "next/dist/shared/lib/get-img-props";
+import Image from "next/image";
+
+type Props = {
+  src: string | StaticImport;
+  alt: string;
+  width: number;
+  height: number;
+  className: string;
+};
+
+export default function Thumbnail({ src, alt, width, height, className }: Props) {
+  return <Image src={src} alt={alt} width={width} height={height} className={className} />;
+}

--- a/components/shopNoticePage/noticeContents/WorkHour.tsx
+++ b/components/shopNoticePage/noticeContents/WorkHour.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+import ClockActive from "@/public/images/clock.svg";
+import ClockInactive from "@/public/images/clock_grey.svg";
+
+type Props = {
+  startsAt: string;
+  workHour: number;
+  isClosed?: boolean;
+};
+
+export default function WorkHour({ startsAt, workHour, isClosed = false }: Props) {
+  const date = getDate(startsAt);
+  const time = getTime(startsAt, workHour);
+  const ImageSrc = isClosed ? ClockInactive : ClockActive;
+  return (
+    <div>
+      <Image src={ImageSrc} alt="시계 모양 아이콘" width={20} height={20} />
+      {date} <span>{time}</span>
+    </div>
+  );
+}
+
+function getDate(sourceDate: string) {
+  const date = new Date(sourceDate);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  return `${[year, month, day].join("-")}`;
+}
+
+function getTime(sourceDate: string, workhour: number) {
+  const date = new Date(sourceDate);
+
+  const hour = date.getHours();
+  const endHour = hour + workhour > 24 ? hour + workhour - 24 : hour + workhour;
+  const minute = (date.getMinutes() < 10 ? "0" : "") + date.getMinutes();
+
+  const startTime = `${hour}:${minute}`;
+  const endTime = `${endHour}:${minute}`;
+
+  return `${startTime}~${endTime} (${workhour}시간)`;
+}


### PR DESCRIPTION
## 주요 구현 사항 ✨

- 사장님의 공고 상세 페이지에서 해당 공고의 세부 내용을 보여주는 컴포넌트입니다.

## 스크린샷 🎨
<img width="360" alt="image" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/e69d0cc1-a1ef-4a63-80f2-e35bb10d5ffe">

## 구체적 구현 사항 설명 📃

- 공고상세 페이지의 상단부 중 식당이름 / 가운데 패널 / 공고 설명 중 '가운데 패널' 부분입니다.
- Panel이라는 컴포넌트를 만들고 여기에 썸네일, 시급(hourlyPay), 시간(workHour), 주소, 가게설명(shopDescription) 컴포넌트를 만들어 컴파운드로 연결시켰습니다.
- 아직 "시급'이라는 타이틀 컴포넌트와 "공고 수정하기"를 위한 버튼 컴포넌트는 연결하지 않았습니다. 다른 pr이 머지되고 나면 연결하겠습니다.
- 아직 css는 구현 전입니다.

## 실사용 예시
```
export default function Notice() {
  return (
    <Panel className={cn("panelContainer")}>
      <Panel.Thumbnail src={Test} alt="리애 돈가스" width={100} height={100} className={cn("thumbnail")} />
      <div className={cn("detailsContainer")}>
        <div className={cn("hourlypayContainer")}>
          <p>시급</p>
          <Panel.HourlyPay hourlypay={15000} className={cn("hourlypay")} />
          <Panel.HourlyPayBadge
            hourlyPay={15000}
            originalHourlyPay={10000}
            className={cn("hourlyPayBadge")}
            iconClassName="badgeIcon"
          />
        </div>
        <Panel.WorkHour startsAt="2024-2-14T08:00:00Z" workHour={8} />
        <Panel.Address address="서울시 강남구" className={cn("address")} isClosed={true} />
        <Panel.shopDescription shopDescription="돈가스는 리애지!" className={cn("shopDescription")} />
      </div>
    </Panel>
  );
}
```

## 논의사항 🤔

- 시간을 가져오는 함수에서 임시 데이터로 "2024-2-14T08:00:00Z"를 사용했는데, console.log()에서는 정상출력되지만 브라우저에서는 NaN으로 출력되네요. 졸려서 일단 자려고요..ㅎ
- 내일 회의 중에도 논의하려 했던 부분 : 버튼 컴포넌트의 공통 컴포넌트 여부
- 저는 왜 이런 기본적인걸 하는데도 오래 걸릴까요?ㅋㅋㅋㅋ
