### PR TITLE
Feat: 사장님 - 공고 상세 - 공고 설명 컴포넌트 구현

### DIFF
--- a/components/shopNoticePage/noticeDescription/NoticeDescription.module.scss
+++ b/components/shopNoticePage/noticeDescription/NoticeDescription.module.scss
@@ -1,0 +1,51 @@
+@use "@/styles/variables.scss" as *;
+
+$mobile-safezone: 1.2rem;
+$tablet-safezone: 3.2rem;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+
+  margin: auto;
+  padding: 2rem;
+  border-radius: 1.2rem;
+
+  max-width: 68rem;
+  width: calc(100% - $mobile-safezone * 2);
+
+  background-color: $color-gray-10;
+
+  @include mobile {
+    gap: 1.2rem;
+    padding: 3.2rem;
+    width: calc(100% - $tablet-safezone * 2);
+  }
+
+  @include desktop {
+    max-width: 96.4rem;
+  }
+}
+
+.title {
+  color: $color-black;
+  font-size: 1.4rem;
+  font-weight: 700;
+
+  @include tablet {
+    font-size: 1.6rem;
+    line-height: 2rem;
+  }
+}
+
+.description {
+  color: $color-black;
+  font-size: 1.4rem;
+  line-height: 2.2rem;
+
+  @include tablet {
+    font-size: 1.6rem;
+    line-height: 2.6rem;
+  }
+}

--- a/components/shopNoticePage/noticeDescription/NoticeDescription.module.scss
+++ b/components/shopNoticePage/noticeDescription/NoticeDescription.module.scss
@@ -33,7 +33,7 @@ $tablet-safezone: 3.2rem;
   font-size: 1.4rem;
   font-weight: 700;
 
-  @include tablet {
+  @include mobile {
     font-size: 1.6rem;
     line-height: 2rem;
   }
@@ -44,7 +44,7 @@ $tablet-safezone: 3.2rem;
   font-size: 1.4rem;
   line-height: 2.2rem;
 
-  @include tablet {
+  @include mobile {
     font-size: 1.6rem;
     line-height: 2.6rem;
   }

--- a/components/shopNoticePage/noticeDescription/NoticeDescription.tsx
+++ b/components/shopNoticePage/noticeDescription/NoticeDescription.tsx
@@ -1,0 +1,17 @@
+import classNames from "classnames/bind";
+import styles from "./NoticeDescription.module.scss";
+
+const cn = classNames.bind(styles);
+
+type Props = {
+  noticeDescription: string;
+};
+
+export default function NoticeDescription({ noticeDescription }: Props) {
+  return (
+    <div className={cn("container")}>
+      <h3 className={cn("title")}>공고 설명</h3>
+      <p className={cn("description")}>{noticeDescription}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## 주요 구현 사항 ✨

- 사장님의 공고 상세 페이지 중 중간에 회색 박스로 공고 설명을 하는 컴폰너트 구현입니다.

## 스크린샷 🎨
모바일 사이즈 이하
<img width="280" alt="스크린샷 2024-01-27 오후 2 32 34" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/92bcdfd5-f511-4eba-bffa-d008621336b0">
<div></div>
태블릿 사이즈 이하
<div></div>
<img width="344" alt="스크린샷 2024-01-27 오후 2 32 46" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/7be04164-012a-428f-af7d-bab37333cc49">
<div></div>
태블릿 사이즈 이상
<div></div>
<img width="673" alt="스크린샷 2024-01-27 오후 2 32 59" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/e0b22c55-4feb-4600-a818-5dc02b2274ef">


## 구체적 구현 사항 설명 📃

- 공고 설명을 prop으로 내려받아 표시합니다.

## 논의사항 🤔

-

