### PR TITLE
feat : 로그인/반응형 UI 구현

### DIFF
--- a/components/common/logo/Logo.module.scss
+++ b/components/common/logo/Logo.module.scss
@@ -1,10 +1,10 @@
 @use "@/styles/variables.scss" as *;
-.small {
+.large {
   width: 24.8rem;
   height: auto;
 }
 
-.large {
+.small {
   width: 10.8rem;
   height: auto;
   min-width: 8.4rem;

--- a/components/common/logo/Logo.module.scss
+++ b/components/common/logo/Logo.module.scss
@@ -1,11 +1,20 @@
 @use "@/styles/variables.scss" as *;
 .large {
-  width: 24.8rem;
+  width: 20.8rem;
   height: auto;
 }
 
 .small {
-  width: 10.8rem;
+  width: 8.4rem;
   height: auto;
-  min-width: 8.4rem;
+}
+
+@include tablet {
+  .large {
+    width: 24.8rem;
+  }
+
+  .small {
+    width: 10.8rem;
+  }
 }

--- a/components/sign/input/input.module.scss
+++ b/components/sign/input/input.module.scss
@@ -1,0 +1,30 @@
+@use "@/styles/variables.scss" as *;
+
+.inputWrap {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.8rem;
+}
+
+.inputLabel {
+  line-height: 2.6rem;
+}
+
+.input {
+  padding: 1.6rem 2rem;
+  border-radius: 6px;
+  border: 1px solid var(--color-gray-30, #cbc9cf);
+  background: var(--color-white, #fff);
+}
+
+.input:focus-within {
+  outline: 1px solid transparent;
+  border: 1px solid var(--color-red-40, #ff4040);
+}
+
+.errorMessage {
+  color: var(--color-red-40, #ff4040);
+  font-size: 1.2rem;
+  line-height: 1.6rem;
+}

--- a/components/sign/input/input.module.scss
+++ b/components/sign/input/input.module.scss
@@ -14,17 +14,17 @@
 .input {
   padding: 1.6rem 2rem;
   border-radius: 6px;
-  border: 1px solid var(--color-gray-30, #cbc9cf);
-  background: var(--color-white, #fff);
+  border: 1px solid $color-gray-30;
+  background: $color-white;
 }
 
 .input:focus-within {
   outline: 1px solid transparent;
-  border: 1px solid var(--color-red-40, #ff4040);
+  border: 1px solid $color-red-40;
 }
 
 .errorMessage {
-  color: var(--color-red-40, #ff4040);
+  color: $color-red-40;
   font-size: 1.2rem;
   line-height: 1.6rem;
 }

--- a/components/sign/input/input.tsx
+++ b/components/sign/input/input.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import styles from "./input.module.scss";
+import classNames from "classnames/bind";
+
+const cn = classNames.bind(styles);
+
+interface InputProps {
+  label: "이메일" | "비밀번호" | "비밀번호 확인";
+  inputType: "email" | "password";
+  errorMessage: "잘못된 이메일입니다." | "8자 이상 입력해 주세요." | "비밀번호가 일치하지 않습니다.";
+}
+
+export default function Input({ label, inputType, errorMessage }: InputProps) {
+  return (
+    <div className={cn("inputWrap")}>
+      <label className={cn("inputLabel")}>{label}</label>
+      <input className={cn("input")} placeholder="입력" type={inputType} />
+      <small className={cn("errorMessage")}>{errorMessage}</small>
+    </div>
+  );
+}

--- a/components/sign/signBotton/SignBottom.module.scss
+++ b/components/sign/signBotton/SignBottom.module.scss
@@ -9,5 +9,5 @@
 }
 
 .signBottomLink {
-  color: var(--color-blue-20, #0090ff);
+  color: $color-blue-20;
 }

--- a/components/sign/signBotton/SignBottom.module.scss
+++ b/components/sign/signBotton/SignBottom.module.scss
@@ -1,0 +1,13 @@
+@use "@/styles/variables.scss" as *;
+
+.signBottonWrap {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.8rem;
+  padding-top: 0.2rem;
+}
+
+.signBottomLink {
+  color: var(--color-blue-20, #0090ff);
+}

--- a/components/sign/signBotton/SignBotton.tsx
+++ b/components/sign/signBotton/SignBotton.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import styles from "./signBottom.module.scss";
+import classNames from "classnames/bind";
+import Link from "next/link";
+
+const cn = classNames.bind(styles);
+
+interface SignBottomProps {
+  text: "회원이 아니신가요?" | "이미 가입하셨나요?";
+  href: "/signup" | "/signin";
+  textLink: "로그인하기" | "회원가입하기";
+}
+
+export default function SignBottom({ text, href, textLink }: SignBottomProps) {
+  return (
+    <div className={cn("signBottonWrap")}>
+      <span className={cn("signBottomText")}>{text}</span>
+      <Link href={href} className={cn("signBottomLink")}>
+        {textLink}
+      </Link>
+    </div>
+  );
+}

--- a/components/sign/signButton/SignButton.module.scss
+++ b/components/sign/signButton/SignButton.module.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  color: var(--color-white, #fff);
-  background: var(--color-red-40, #ea3c12);
+  color: $color-white;
+  background: $color-red-40;
   cursor: pointer;
 }

--- a/components/sign/signButton/SignButton.module.scss
+++ b/components/sign/signButton/SignButton.module.scss
@@ -1,0 +1,11 @@
+.signButton {
+  display: inline-flex;
+  padding: 1.4rem 1.36rem;
+  border-radius: 0.6rem;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  color: var(--color-white, #fff);
+  background: var(--color-red-40, #ea3c12);
+  cursor: pointer;
+}

--- a/components/sign/signButton/SignButton.module.scss
+++ b/components/sign/signButton/SignButton.module.scss
@@ -1,3 +1,5 @@
+@use "@/styles/variables.scss" as *;
+
 .signButton {
   display: inline-flex;
   padding: 1.4rem 1.36rem;

--- a/components/sign/signButton/SignButton.tsx
+++ b/components/sign/signButton/SignButton.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import styles from "./signButton.module.scss";
+import classNames from "classnames/bind";
+
+const cn = classNames.bind(styles);
+
+interface SignButtonProps {
+  text: "로그인 하기" | "가입하기";
+}
+
+export default function SignButton({ text }: SignButtonProps) {
+  return (
+    <div>
+      <button className={cn("signButton")}>{text}</button>
+    </div>
+  );
+}

--- a/components/sign/signLayout/SignLayout.module.scss
+++ b/components/sign/signLayout/SignLayout.module.scss
@@ -1,0 +1,28 @@
+@use "@/styles/variables.scss" as *;
+
+.signLayoutWrap {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.signWrap {
+  width: 35rem;
+  padding: 1.2rem;
+}
+
+.logoWarp {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 4rem;
+}
+.inputLayout {
+  display: flex;
+  flex-direction: column;
+  gap: 2.8rem;
+}
+.signBottomWrap {
+  margin-top: 2rem;
+}

--- a/components/sign/signLayout/SignLayout.tsx
+++ b/components/sign/signLayout/SignLayout.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import styles from "./SignLayout.module.scss";
+import classNames from "classnames/bind";
+import Logo from "@/components/common/logo/Logo";
+import Input from "@/components/sign/input/input";
+import SignBottom from "@/components/sign/signBotton/SignBotton";
+import SignButton from "@/components/sign/signButton/SignButton";
+
+const cn = classNames.bind(styles);
+
+export default function SignLayout() {
+  return (
+    <div className={cn("signLayoutWrap")}>
+      <div className={cn("signWrap")}>
+        <div className={cn("logoWarp")}>
+          <Logo size="large" />
+        </div>
+        <div className={cn("inputLayout")}>
+          <Input label="이메일" inputType="email" errorMessage="잘못된 이메일입니다." />
+          <Input label="비밀번호" inputType="password" errorMessage="8자 이상 입력해 주세요." />
+          <SignButton text="로그인 하기" />
+        </div>
+        <div className={cn("signBottomWrap")}>
+          <SignBottom text="이미 가입하셨나요?" href="/signin" textLink="로그인하기" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 주요 구현 사항 ✨


- 로고 반응형 수정 #39 
- 버튼 (로그인하기) 컴포넌트 구현  #19 
- 텍스트링크(회원이 아니신가요? 회원가입하기) 컴포넌트 구현
 #23 
- input UI 구현
- 레이아웃 구성
- 반응형 UI 구현

## 스크린샷 🎨

- PC & Tablet
![image](https://github.com/sprintPart3Team4/the-julge/assets/84887815/d508afa5-9632-4933-8bc8-6f11079ec803)

- Mobile
![image](https://github.com/sprintPart3Team4/the-julge/assets/84887815/6e858dca-05d4-4ad8-82ce-a6f050ec9847)


## 구체적 구현 사항 설명 📃

### 로고 
- 모바일에서 PC로 css 반응형 구현방식을 수정하였습니다.

### 텍스트링크(회원이 아니신가요? 회원가입하기) 컴포넌트 구현 (SignBottom.tsx)
- UI만 구현하려 했는데 이슈가 너무 나눠지는 것 같아 기능구현까지 같이 하였습니다. 
- 로그인과 회원가입 페이지에서 모두 사용할 수 있도록 구현하였습니다.
- 로그인하기 또는 회원가입하기 클릭시 해당 페이지로 이동합니다.
- 실사용 예시
- `<SignBottom text="이미 가입하셨나요?" href="/signin" textLink="로그인하기" />`
- `<SignBottom text="회원이 아니신가요?" href="/signup" textLink="회원가입하기" />`

### UI 구현
- input
- 레이아웃 구성
- 반응형 UI 구현

## 논의사항 🤔

- 버튼 컴포넌트에 대한 논의중이었어서 로그인페이지만 적용될 수 있는 버튼으로 임시 작업하였습니다.
- 대략적인 UI만 잡아보았고 이후 input 컴포넌트 등 기능이 완성되면 다시 수정하도록 하겠습니다.
