### PR TITLE
Design: 사장님/가게정보상세 반응형 컴포넌트

### DIFF
--- a/components/shop/myShopProfile/MyShopProfile.module.scss
+++ b/components/shop/myShopProfile/MyShopProfile.module.scss
@@ -1,55 +1,107 @@
 @use "@/styles/variables.scss" as *;
 
+// 모바일 사이즈를 디폴트로
 .container {
+  position: relative;
   display: flex;
   justify-content: space-between;
-  gap: 3.2rem;
-  padding: 2.4rem;
-  width: 96.4rem;
+  flex-direction: column;
+  padding: 2rem;
+  gap: 1.2rem;
+  max-width: 68rem;
+  width: calc(100% - 2.4rem);
   border-radius: 1.2rem;
   background: $color-red-10;
+  font-size: 1.4rem;
+
+  @include tablet {
+    gap: 1.6rem;
+    padding: 2.4rem;
+    width: calc(100% - 6.4rem);
+  }
+
+  @include desktop {
+    flex-direction: row;
+    gap: 2.8rem;
+    max-width: 96.4rem;
+  }
 
   .image {
     border-radius: 1.2rem;
+    width: 100%;
+    height: auto;
   }
 
   .contents {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    gap: 2.4rem;
+
+    @include tablet {
+      gap: 4rem;
+    }
+
+    @include desktop {
+      justify-content: space-between;
+    }
   }
 
   .shopInfo {
     display: flex;
     flex-direction: column;
-    gap: 1.2rem;
-    margin-top: 1.6rem;
+    gap: 0.8rem;
+
+    @include tablet {
+      gap: 1.2rem;
+    }
+
+    @include desktop {
+      margin-top: 1.6rem;
+    }
   }
 
   .category {
     color: $color-red-40;
     font-weight: 700;
-    margin-bottom: -0.4rem;
+    margin-bottom: 0;
+
+    @include tablet {
+      margin-bottom: -0.4rem;
+    }
   }
 
   .name {
     color: $color-black;
-    font-size: 2.8rem;
+    font-size: 2.4rem;
     font-weight: 700;
     letter-spacing: 0.06rem;
+
+    @include tablet {
+      font-size: 2.8rem;
+    }
   }
+
+  // TODO svg 반응형 추가
 
   .location {
     display: flex;
     align-items: center;
     gap: 0.6rem;
     color: $color-gray-50;
-    line-height: 2.6rem;
+    line-height: 2.2rem;
+
+    @include tablet {
+      line-height: 2.6rem;
+    }
   }
 
   .description {
     color: $color-black;
-    line-height: 2.6rem;
+    line-height: 2.2rem;
+
+    @include tablet {
+      line-height: 2.6rem;
+    }
   }
 
   .buttons {
@@ -59,28 +111,30 @@
 
   .button {
     display: flex;
-    padding: 1.4rem;
+    flex-grow: 1;
+    padding: 1rem;
     justify-content: center;
     align-items: center;
-    gap: 0.8rem;
-    width: 16.9rem;
+    width: 15.1rem;
     border: 1px solid $color-red-40;
     border-radius: 0.6rem;
+    text-align: center;
+    font-weight: 700;
+
+    @include tablet {
+      padding: 1.4rem;
+      width: 16.9rem;
+      line-height: 2rem;
+    }
   }
 
   .whiteButton {
     background: $color-white;
     color: $color-red-40;
-    text-align: center;
-    font-weight: 700;
-    line-height: 2rem;
   }
 
   .primaryButton {
     background-color: $color-red-40;
     color: $color-white;
-    text-align: center;
-    font-weight: 700;
-    line-height: 2rem;
   }
 }

--- a/components/shop/myShopProfile/MyShopProfile.module.scss
+++ b/components/shop/myShopProfile/MyShopProfile.module.scss
@@ -81,8 +81,6 @@
     }
   }
 
-  // TODO svg 반응형 추가
-
   .location {
     display: flex;
     align-items: center;
@@ -92,6 +90,14 @@
 
     @include tablet {
       line-height: 2.6rem;
+    }
+
+    img {
+      width: 1.6rem;
+
+      @include tablet {
+        width: 2rem;
+      }
     }
   }
 

--- a/components/shop/myShopProfile/MyShopProfile.tsx
+++ b/components/shop/myShopProfile/MyShopProfile.tsx
@@ -10,7 +10,7 @@ const cn = classNames.bind(styles);
 export default function MyShopProfile() {
   return (
     <div className={cn("container")}>
-      <Image src={TestImage} className={cn("image")} alt="테스트 이미지" width={538} />
+      <Image src={TestImage} className={cn("image")} alt="테스트 이미지" objectFit="cover" />
       <div className={cn("contents")}>
         <div className={cn("shopInfo")}>
           <span className={cn("category")}>{storeInfo.item.category}</span>

--- a/components/shop/myShopProfile/MyShopProfile.tsx
+++ b/components/shop/myShopProfile/MyShopProfile.tsx
@@ -15,7 +15,6 @@ export default function MyShopProfile() {
         <div className={cn("shopInfo")}>
           <span className={cn("category")}>{storeInfo.item.category}</span>
           <span className={cn("name")}>{storeInfo.item.name}</span>
-
           <div className={cn("location")}>
             <Image src={LocationIcon} alt="위치 아이콘" width={20} height={20} />
             <span>{storeInfo.item.address1}</span>

--- a/components/shop/noticeCard/NoticeCard.module.scss
+++ b/components/shop/noticeCard/NoticeCard.module.scss
@@ -1,17 +1,30 @@
 @use "@/styles/variables.scss" as *;
 
 .container {
+  // container의 width 값은 레이아웃 UI 작업하며 그리드에 맞게 변경할 예정입니다.
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 1.6rem;
-  gap: 2rem;
-  width: 31.2rem;
+  gap: 1.2rem;
+  padding: 1.2rem;
+  width: 17.1rem;
   border-radius: 1.2rem;
-  border: 1px solid $color-gray-20;
+  border: 0.1rem solid $color-gray-20;
   background: $color-white;
 
+  @include tablet {
+    padding: 1.6rem;
+    gap: 2rem;
+    width: 33.2rem;
+  }
+
+  @include desktop {
+    width: 31.2rem;
+  }
+
   .image {
+    width: 100%;
+    height: auto;
     border-radius: 1.2rem;
   }
 
@@ -23,8 +36,13 @@
 
   .shopName {
     color: $color-black;
-    font-size: 2rem;
     font-weight: 700;
+    line-height: 2rem;
+
+    @include tablet {
+      font-size: 2rem;
+      line-height: normal;
+    }
   }
 
   .time,
@@ -33,19 +51,33 @@
     align-items: center;
     gap: 0.6rem;
     color: $color-gray-50;
-    line-height: 2.2rem;
+    font-size: 1.2rem;
+    line-height: 1.6rem;
+
+    @include tablet {
+      font-size: 1.4rem;
+      line-height: 2.2rem;
+    }
+
+    img {
+      width: 1.6rem;
+
+      @include tablet {
+        width: 2rem;
+      }
+    }
   }
 
   .pay {
     margin-top: 0.8rem;
     color: $color-black;
-    font-size: 2.4rem;
+    font-size: 1.8rem;
     font-weight: 700;
-    letter-spacing: 0.05rem;
-  }
 
-  svg {
-    fill: $color-red-30;
+    @include tablet {
+      font-size: 2.4rem;
+      letter-spacing: 0.05rem;
+    }
   }
 }
 
@@ -57,15 +89,24 @@
     justify-content: center;
     align-items: center;
     position: absolute;
-    width: 28rem;
-    height: 16rem;
+    width: 14.5rem;
+    height: 8.3rem;
     background-color: rgba($color: $color-black, $alpha: 0.5);
     border-radius: 1.2rem;
     color: $color-gray-30;
     text-align: center;
-    font-size: 2.8rem;
+    font-size: 2rem;
     font-weight: 700;
-    letter-spacing: 0.06rem;
+
+    @include tablet {
+      width: 27.8rem;
+      height: 15.9rem;
+      font-size: 2.8rem;
+      letter-spacing: 0.06rem;
+    }
+
+    @include desktop {
+    }
   }
 
   .shopName,
@@ -73,9 +114,5 @@
   .location,
   .pay {
     color: $color-gray-30;
-  }
-
-  svg {
-    fill: $color-gray-30;
   }
 }

--- a/components/shop/noticeCard/NoticeCard.tsx
+++ b/components/shop/noticeCard/NoticeCard.tsx
@@ -18,17 +18,17 @@ export default function NoticeCard({ isClosed = false }: NoticeCardProps) {
   return (
     <div className={cn("container", { closed: isClosed })}>
       {isClosed && <div className={cn("imgOverlay")}>마감 완료</div>}
-      <Image className={cn("image")} src={TestImage} alt="테스트 이미지" width={280} />
+      <Image className={cn("image")} src={TestImage} alt="테스트 이미지" />
       <div className={cn("contents")}>
         <span className={cn("shopName")}>{storeInfo.item.name}</span>
         <div className={cn("time")}>
-          <Image src={isClosed ? GreyClockIcon : ClockIcon} alt="시계 아이콘" width={20} />
+          <Image src={isClosed ? GreyClockIcon : ClockIcon} alt="시계 아이콘" />
           <span>
             {noticeList.items[0].item.startsAt} ({noticeList.items[0].item.workhour}시간)
           </span>
         </div>
         <div className={cn("location")}>
-          <Image src={isClosed ? GreyLocationIcon : LocationIcon} alt="장소 아이콘" width={20} />
+          <Image src={isClosed ? GreyLocationIcon : LocationIcon} alt="장소 아이콘" />
           <span>{storeInfo.item.address1}</span>
         </div>
         <span className={cn("pay")}>{noticeList.items[0].item.hourlyPay.toLocaleString()}원</span>

--- a/components/shop/noticeSuggestion/NoticeSuggestion.module.scss
+++ b/components/shop/noticeSuggestion/NoticeSuggestion.module.scss
@@ -2,33 +2,55 @@
 
 .container {
   display: flex;
-  width: 96.4rem;
+  max-width: 68rem;
+  width: calc(100% - 2.4rem);
   padding: 6rem 2.4rem;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 2.4rem;
+  gap: 1.6rem;
   border-radius: 1.2rem;
   border: 0.1rem solid $color-gray-20;
 
+  @include tablet {
+    gap: 2.4rem;
+    width: calc(100% - 6.4rem);
+  }
+
+  @include desktop {
+    max-width: 96.4rem;
+  }
+
   span {
     color: #111322;
+    font-size: 1.4rem;
     text-align: center;
-    line-height: 2.6rem;
+    line-height: 2.2rem;
+
+    @include tablet {
+      font-size: 1.6rem;
+      line-height: 2.6rem;
+    }
   }
 
   button {
     display: flex;
-    width: 34.6rem;
-    height: 4.7rem;
     justify-content: center;
     align-items: center;
-    gap: 0.8rem;
+    padding: 1rem 2rem;
+    height: 3.7rem;
     border-radius: 0.6rem;
     background: $color-red-40;
     color: $color-white;
+    font-size: 1.4rem;
     text-align: center;
     font-weight: 700;
-    line-height: 2rem;
+
+    @include tablet {
+      width: 34.6rem;
+      height: 4.7rem;
+      font-size: 1.6rem;
+      line-height: 2rem;
+    }
   }
 }

--- a/components/shop/shopPageLayout/ShopPageLayout.module.scss
+++ b/components/shop/shopPageLayout/ShopPageLayout.module.scss
@@ -1,0 +1,6 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}

--- a/components/shop/shopPageLayout/ShopPageLayout.tsx
+++ b/components/shop/shopPageLayout/ShopPageLayout.tsx
@@ -9,7 +9,7 @@ const cn = classNames.bind(styles);
 export default function ShopPageLayout() {
   return (
     <div className={cn("container")}>
-      <MyShopProfile />
+      <NoticeSuggestion />
     </div>
   );
 }

--- a/components/shop/shopPageLayout/ShopPageLayout.tsx
+++ b/components/shop/shopPageLayout/ShopPageLayout.tsx
@@ -1,0 +1,15 @@
+import classNames from "classnames/bind";
+import MyShopProfile from "@/components/shop/myShopProfile/MyShopProfile";
+import NoticeCard from "@/components/shop/noticeCard/NoticeCard";
+import NoticeSuggestion from "@/components/shop/noticeSuggestion/NoticeSuggestion";
+import styles from "./ShopPageLayout.module.scss";
+
+const cn = classNames.bind(styles);
+
+export default function ShopPageLayout() {
+  return (
+    <div className={cn("container")}>
+      <MyShopProfile />
+    </div>
+  );
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,8 +1,8 @@
-import { Html, Head, Main, NextScript } from 'next/document';
+import { Html, Head, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
-    <Html lang='ko'>
+    <Html lang="ko">
       <Head />
       <body>
         <Main />

--- a/pages/shop/index.tsx
+++ b/pages/shop/index.tsx
@@ -1,5 +1,11 @@
+import NoticeCard from "@/components/shop/noticeCard/NoticeCard";
 import ShopPageLayout from "@/components/shop/shopPageLayout/ShopPageLayout";
 
 export default function ShopPage() {
-  return <ShopPageLayout />;
+  return (
+    <>
+      <NoticeCard />
+      <NoticeCard isClosed />
+    </>
+  );
 }

--- a/pages/shop/index.tsx
+++ b/pages/shop/index.tsx
@@ -1,11 +1,11 @@
 import NoticeCard from "@/components/shop/noticeCard/NoticeCard";
+import NoticeSuggestion from "@/components/shop/noticeSuggestion/NoticeSuggestion";
 import ShopPageLayout from "@/components/shop/shopPageLayout/ShopPageLayout";
 
 export default function ShopPage() {
   return (
     <>
-      <NoticeCard />
-      <NoticeCard isClosed />
+      <ShopPageLayout />
     </>
   );
 }

--- a/pages/shop/index.tsx
+++ b/pages/shop/index.tsx
@@ -1,18 +1,5 @@
-import MyShopProfile from "@/components/shop/myShopProfile/MyShopProfile";
-import NoticeCard from "@/components/shop/noticeCard/NoticeCard";
-import NoticeSuggestion from "@/components/shop/noticeSuggestion/NoticeSuggestion";
+import ShopPageLayout from "@/components/shop/shopPageLayout/ShopPageLayout";
 
 export default function ShopPage() {
-  return (
-    <div>
-      <h1>1. 내 가게 컴포넌트</h1>
-      <MyShopProfile />
-      <h1>2. 공고 카드 컴포넌트</h1>
-      <NoticeCard />
-      <h2>* 마감 시</h2>
-      <NoticeCard isClosed />
-      <h1>3. 등록한 공고가 없을 시</h1>
-      <NoticeSuggestion />
-    </div>
-  );
+  return <ShopPageLayout />;
 }


### PR DESCRIPTION
## 주요 구현 사항 ✨

- issue: #6 
- 가게 정보 상세 페이지에 들어가는 주요 컴포넌트들의 반응형 UI를 구현했습니다.

## 스크린샷 🎨

### desktop
![image](https://github.com/sprintPart3Team4/the-julge/assets/148641571/038bfb69-2b9e-4f6f-9f59-6108884c8b62)

### tablet
![image](https://github.com/sprintPart3Team4/the-julge/assets/148641571/63781807-eed1-4e80-b22c-5dc5c593e3c3)
공고 카드 컴포넌트 width는 그리드 만들면서 조정하려고 해서 마감 완료 검정 오버레이 사이즈 안 맞는 건 그때 해결해보도록 하겠습니다 :)

### mobile
![image](https://github.com/sprintPart3Team4/the-julge/assets/148641571/db516d65-d955-4ce1-8ddc-2539944ff9ca)


## 구체적 구현 사항 설명 📃
- 기존 desktop을 기준으로 만들었던 컴포넌트 css 스타일을 모바일을 기준으로 바꿨습니다.
- variables.scss 파일의 mixin을 이용해 작업했던 컴포넌트들을 mobile, tablet, desktop 반응형으로 구현하였습니다.

## 논의사항 🤔

- scss 문법을 잘 사용해보고 싶은데 어떻게 잘 사용해야 할지 모르겠네요.. 혹시 개선점이 보이신다면 말씀해주세요^~^

