### PR TITLE
Design: 공통/Footer - css 수정, email 링크 추가

### DIFF
--- a/components/common/footer/Footer.module.scss
+++ b/components/common/footer/Footer.module.scss
@@ -5,84 +5,106 @@
   line-height: 2.6rem;
 }
 
-@include desktop {
-  .borderBox {
-    position: fixed;
-    bottom: 0;
+.borderBox {
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  width: 100%;
+  min-width: 37.5rem;
+  height: 12.6rem;
+  padding: 3.2rem;
+  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.8rem;
+  background: $color-gray-10;
+
+  .contentBox {
     display: flex;
-    width: 100%;
-    min-width: 37.5rem;
-    height: 10rem;
-    padding: 3.7rem 23.8rem;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.8rem;
-    background: $color-gray-10;
-  
-    .contentBox {
+    flex-wrap: wrap-reverse;
+    justify-content: space-between;
+    align-items: center;
+    align-self: stretch;
+
+    .content {
+      width: 35%;
+    }
+
+    .company {
+      @include text;
+      margin-top: 2.5rem;
+      width: 100%;
+    }
+
+    .customerSupport {
       display: flex;
-      justify-content: space-between;
-      align-items: center;
-      align-self: stretch;
-  
-      .company {
+      width: 18rem;
+      align-items: flex-start;
+      gap: 3rem;
+
+      .privacyPolicy {
         @include text;
       }
-  
-      .customerSupport {
-        display: flex;
-        width: 18rem;
-        align-items: flex-start;
-        gap: 3rem;
-  
-        .privacyPolicy {
-          @include text;
-        }
-  
-        .faq {
-          @include text;
-        }
-      }
-  
-      .sns {
-        display: flex;
-        align-items: flex-start;
-        gap: 1rem;
+
+      .faq {
+        @include text;
       }
     }
-  }
 
+    .sns {
+      display: flex;
+      align-items: flex-start;
+      justify-content: flex-end;
+      gap: 1rem;
+    }
+  }
 }
 
 @include tablet {
   .borderBox {
+    height: 10rem;
     padding: 3.2rem;
-    min-width: 37.5rem;
-  }
-}
-
-@include mobile {
-  .borderBox {
-    min-width: 37.5rem;
-    height: 12.6rem;
-    padding: 3.2rem;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 
     .contentBox {
-      flex-wrap: wrap-reverse;
-      justify-content: space-between;
+      flex-wrap: nowrap;
 
       .content {
-        width: 35%;
+        width: 0;
       }
 
       .company {
-        margin-top: 2.5rem;
-        width: 100%;
+        margin: 0;
+        width: auto;
+      }
+
+      .customerSupport {
+        flex-wrap: nowrap;
       }
 
       .sns {
-        justify-content: flex-end;
+        justify-content: flex-start;
+      }
+    }
+  }
+}
+
+@include desktop {
+  .borderBox {
+    height: 10rem;
+    padding: 3.7rem 23.8rem;
+    flex-wrap: nowrap;
+
+    .contentBox {
+      display: flex;
+      flex-wrap: nowrap;
+
+      .customerSupport {
+        flex-wrap: nowrap;
+
+        .sns {
+          justify-content: flex-start;
+        }
       }
     }
   }

--- a/components/common/footer/Footer.module.scss
+++ b/components/common/footer/Footer.module.scss
@@ -1,0 +1,89 @@
+@use "@/styles/variables.scss" as *;
+
+@mixin text {
+  color: $color-gray-50;
+  line-height: 2.6rem;
+}
+
+@include desktop {
+  .borderBox {
+    position: fixed;
+    bottom: 0;
+    display: flex;
+    width: 100%;
+    min-width: 37.5rem;
+    height: 10rem;
+    padding: 3.7rem 23.8rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.8rem;
+    background: $color-gray-10;
+  
+    .contentBox {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      align-self: stretch;
+  
+      .company {
+        @include text;
+      }
+  
+      .customerSupport {
+        display: flex;
+        width: 18rem;
+        align-items: flex-start;
+        gap: 3rem;
+  
+        .privacyPolicy {
+          @include text;
+        }
+  
+        .faq {
+          @include text;
+        }
+      }
+  
+      .sns {
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+      }
+    }
+  }
+
+}
+
+@include tablet {
+  .borderBox {
+    padding: 3.2rem;
+    min-width: 37.5rem;
+  }
+}
+
+@include mobile {
+  .borderBox {
+    min-width: 37.5rem;
+    height: 12.6rem;
+    padding: 3.2rem;
+    flex-wrap: wrap;
+
+    .contentBox {
+      flex-wrap: wrap-reverse;
+      justify-content: space-between;
+
+      .content {
+        width: 35%;
+      }
+
+      .company {
+        margin-top: 2.5rem;
+        width: 100%;
+      }
+
+      .sns {
+        justify-content: flex-end;
+      }
+    }
+  }
+}

--- a/components/common/footer/Footer.tsx
+++ b/components/common/footer/Footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
                     <p className={cn("faq")}>FAQ</p>
                 </div>
                 <div className={cn("sns")}>
-                    <Link href={"malito:"}><Image src="/images/envelope.svg" width={25} height={25} alt="envelope" /></Link>
+                    <Link href={"mailto:support@codeit.kr"}><Image src="/images/envelope.svg" width={25} height={25} alt="envelope" /></Link>
                     <Link href={"https://www.facebook.com/"}><Image src="/images/facebook.svg" width={25} height={25} alt="facebook" /></Link>
                     <Link href={"https://www.instagram.com/"}><Image src="/images/instagram.svg" width={25} height={25} alt="instagram" /></Link>
                 </div>

--- a/components/common/footer/Footer.tsx
+++ b/components/common/footer/Footer.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import Image from "next/image";
+import classNames from "classnames/bind";
+import styles from "./Footer.module.scss";
+
+const cn = classNames.bind(styles);
+
+export default function Footer() {
+    return(
+        <div className={cn("borderBox")}>
+            <div className={cn("contentBox")}>
+                <div className={cn("company")}><p>©codeit - 2023</p></div>
+                <div className={cn("customerSupport")}>
+                    <p className={cn("privacyPolicy")}>Privacy Policy</p>
+                    <p className={cn("faq")}>FAQ</p>
+                </div>
+                <div className={cn("sns")}>
+                    <Link href={"malito:"}><Image src="/images/envelope.svg" width={25} height={25} alt="envelope" /></Link>
+                    <Link href={"https://www.facebook.com/"}><Image src="/images/facebook.svg" width={25} height={25} alt="facebook" /></Link>
+                    <Link href={"https://www.instagram.com/"}><Image src="/images/instagram.svg" width={25} height={25} alt="instagram" /></Link>
+                </div>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## 주요 구현 사항 ✨

- variable 파일의 미디어 쿼리 사용
- 이메일 이미지 클릭시 "support@codeit.kr"로 이메일 작성 페이지 띄우기
- 컴포넌트 파일명을 파스칼 케이스로 변경했습니다

## 스크린샷 🎨

- 
![2024-01-29053033-ezgif com-video-to-gif-converter](https://github.com/sprintPart3Team4/the-julge/assets/145626840/ec647ff4-b654-41ea-b08d-606b213d7ed6)


## 구체적 구현 사항 설명 📃

- 뷰포트가 375픽셀 미만일 때는 더이상 변하지 않게 했습니다.




## 논의사항 🤔

- 레이아웃을 데스크탑부터 짜면 안될 것 같습니다....ㅜㅜ

