### PR TITLE
Design: 사장님/가게정보상세 - 레이아웃 안에서 컴포넌트 반응형

### DIFF
--- a/components/shop/myShopProfile/MyShopProfile.module.scss
+++ b/components/shop/myShopProfile/MyShopProfile.module.scss
@@ -1,15 +1,13 @@
 @use "@/styles/variables.scss" as *;
 
-// 모바일 사이즈를 디폴트로
-.container {
+.wrap {
   position: relative;
   display: flex;
   justify-content: space-between;
   flex-direction: column;
   padding: 2rem;
   gap: 1.2rem;
-  max-width: 68rem;
-  width: calc(100% - 2.4rem);
+  width: 100%;
   border-radius: 1.2rem;
   background: $color-red-10;
   font-size: 1.4rem;
@@ -17,13 +15,13 @@
   @include tablet {
     gap: 1.6rem;
     padding: 2.4rem;
-    width: calc(100% - 6.4rem);
+    width: 100%;
   }
 
   @include desktop {
     flex-direction: row;
     gap: 2.8rem;
-    max-width: 96.4rem;
+    min-width: 100%;
   }
 
   .image {

--- a/components/shop/myShopProfile/MyShopProfile.module.scss
+++ b/components/shop/myShopProfile/MyShopProfile.module.scss
@@ -28,6 +28,11 @@
     border-radius: 1.2rem;
     width: 100%;
     height: auto;
+
+    @include desktop {
+      width: 53.9rem;
+      height: 30.8rem;
+    }
   }
 
   .contents {

--- a/components/shop/myShopProfile/MyShopProfile.tsx
+++ b/components/shop/myShopProfile/MyShopProfile.tsx
@@ -9,7 +9,7 @@ const cn = classNames.bind(styles);
 
 export default function MyShopProfile() {
   return (
-    <div className={cn("container")}>
+    <div className={cn("wrap")}>
       <Image src={TestImage} className={cn("image")} alt="테스트 이미지" objectFit="cover" />
       <div className={cn("contents")}>
         <div className={cn("shopInfo")}>

--- a/components/shop/noticeCard/NoticeCard.module.scss
+++ b/components/shop/noticeCard/NoticeCard.module.scss
@@ -1,13 +1,13 @@
 @use "@/styles/variables.scss" as *;
 
-.container {
-  // container의 width 값은 레이아웃 UI 작업하며 그리드에 맞게 변경할 예정입니다.
+.wrap {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   gap: 1.2rem;
   padding: 1.2rem;
-  width: 17.1rem;
+  width: 100%;
+  height: auto;
   border-radius: 1.2rem;
   border: 0.1rem solid $color-gray-20;
   background: $color-white;
@@ -15,11 +15,6 @@
   @include tablet {
     padding: 1.6rem;
     gap: 2rem;
-    width: 33.2rem;
-  }
-
-  @include desktop {
-    width: 31.2rem;
   }
 
   .image {

--- a/components/shop/noticeCard/NoticeCard.tsx
+++ b/components/shop/noticeCard/NoticeCard.tsx
@@ -16,7 +16,7 @@ type NoticeCardProps = {
 
 export default function NoticeCard({ isClosed = false }: NoticeCardProps) {
   return (
-    <div className={cn("container", { closed: isClosed })}>
+    <div className={cn("wrap", { closed: isClosed })}>
       {isClosed && <div className={cn("imgOverlay")}>마감 완료</div>}
       <Image className={cn("image")} src={TestImage} alt="테스트 이미지" />
       <div className={cn("contents")}>

--- a/components/shop/noticeCardList/NoticeCardList.module.scss
+++ b/components/shop/noticeCardList/NoticeCardList.module.scss
@@ -1,0 +1,16 @@
+@use "@/styles/variables.scss" as *;
+
+.wrap {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.6rem 0.9rem;
+  width: 100%;
+
+  @include tablet {
+    gap: 3.2rem 1.4rem;
+  }
+
+  @include desktop {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}

--- a/components/shop/noticeCardList/NoticeCardList.tsx
+++ b/components/shop/noticeCardList/NoticeCardList.tsx
@@ -1,0 +1,28 @@
+import classNames from "classnames/bind";
+import NoticeCard from "../noticeCard/NoticeCard";
+import styles from "./NoticeCardList.module.scss";
+
+const cn = classNames.bind(styles);
+
+export default function NoticeCardList() {
+  return (
+    // api 구현 후 map 메소드 사용하여 나열 예정
+    <div className={cn("wrap")}>
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+      <NoticeCard />
+    </div>
+  );
+}

--- a/components/shop/noticeSuggestion/NoticeSuggestion.module.scss
+++ b/components/shop/noticeSuggestion/NoticeSuggestion.module.scss
@@ -1,9 +1,8 @@
 @use "@/styles/variables.scss" as *;
 
-.container {
+.wrap {
   display: flex;
-  max-width: 68rem;
-  width: calc(100% - 2.4rem);
+  width: 100%;
   padding: 6rem 2.4rem;
   flex-direction: column;
   justify-content: center;
@@ -14,11 +13,6 @@
 
   @include tablet {
     gap: 2.4rem;
-    width: calc(100% - 6.4rem);
-  }
-
-  @include desktop {
-    max-width: 96.4rem;
   }
 
   span {

--- a/components/shop/noticeSuggestion/NoticeSuggestion.tsx
+++ b/components/shop/noticeSuggestion/NoticeSuggestion.tsx
@@ -5,7 +5,7 @@ const cn = classNames.bind(styles);
 
 export default function NoticeSuggestion() {
   return (
-    <div className={cn("container")}>
+    <div className={cn("wrap")}>
       <span>공고를 등록해 보세요.</span>
       <button>공고 등록하기</button>
     </div>

--- a/components/shop/shopPageLayout/ShopPageLayout.module.scss
+++ b/components/shop/shopPageLayout/ShopPageLayout.module.scss
@@ -1,21 +1,24 @@
 @use "@/styles/variables.scss" as *;
 
 .wrap {
-  margin: 0rem;
+  margin: 0 auto;
 
   section {
     display: flex;
     flex-direction: column;
     gap: 1.6rem;
-    padding: 4rem 1.2rem;
+    box-sizing: content-box;
+    margin: 4rem 1.2rem;
 
     @include tablet {
       gap: 3.2rem;
-      padding: 6rem 3.2rem;
+      margin: 6rem 3.2rem;
+      // max-width: 68rem; - 이렇게 하는 게 좋을지?
     }
 
     @include desktop {
-      padding: 6rem 23.8rem;
+      margin: 6rem auto;
+      width: 96.4rem;
     }
   }
 

--- a/components/shop/shopPageLayout/ShopPageLayout.module.scss
+++ b/components/shop/shopPageLayout/ShopPageLayout.module.scss
@@ -1,3 +1,31 @@
-.container {
-  margin: 10rem;
+@use "@/styles/variables.scss" as *;
+
+.wrap {
+  margin: 0rem;
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.6rem;
+    padding: 4rem 1.2rem;
+
+    @include tablet {
+      gap: 3.2rem;
+      padding: 6rem 3.2rem;
+    }
+
+    @include desktop {
+      padding: 6rem 23.8rem;
+    }
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 2rem;
+
+    @include tablet {
+      font-size: 2.8rem;
+      letter-spacing: 0.06rem;
+    }
+  }
 }

--- a/components/shop/shopPageLayout/ShopPageLayout.module.scss
+++ b/components/shop/shopPageLayout/ShopPageLayout.module.scss
@@ -1,6 +1,3 @@
 .container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  margin: 10rem;
 }

--- a/components/shop/shopPageLayout/ShopPageLayout.tsx
+++ b/components/shop/shopPageLayout/ShopPageLayout.tsx
@@ -7,10 +7,21 @@ import styles from "./ShopPageLayout.module.scss";
 
 const cn = classNames.bind(styles);
 
-export default function ShopPageLayout() {
+type ShopPageLayoutProps = {
+  hasNotice?: boolean;
+};
+
+export default function ShopPageLayout({ hasNotice }: ShopPageLayoutProps) {
   return (
-    <div className={cn("container")}>
-      <NoticeCardList />
+    <div className={cn("wrap")}>
+      <section>
+        <h2>내 가게</h2>
+        <MyShopProfile />
+      </section>
+      <section>
+        <h2>{hasNotice ? "내가 등록한 공고" : "등록한 공고"}</h2>
+        {hasNotice ? <NoticeCardList /> : <NoticeSuggestion />}
+      </section>
     </div>
   );
 }

--- a/components/shop/shopPageLayout/ShopPageLayout.tsx
+++ b/components/shop/shopPageLayout/ShopPageLayout.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames/bind";
 import MyShopProfile from "@/components/shop/myShopProfile/MyShopProfile";
 import NoticeCard from "@/components/shop/noticeCard/NoticeCard";
 import NoticeSuggestion from "@/components/shop/noticeSuggestion/NoticeSuggestion";
+import NoticeCardList from "../noticeCardList/NoticeCardList";
 import styles from "./ShopPageLayout.module.scss";
 
 const cn = classNames.bind(styles);
@@ -9,7 +10,7 @@ const cn = classNames.bind(styles);
 export default function ShopPageLayout() {
   return (
     <div className={cn("container")}>
-      <NoticeSuggestion />
+      <NoticeCardList />
     </div>
   );
 }

--- a/pages/shop/index.tsx
+++ b/pages/shop/index.tsx
@@ -6,6 +6,7 @@ export default function ShopPage() {
   return (
     <>
       <ShopPageLayout />
+      <ShopPageLayout hasNotice />
     </>
   );
 }


### PR DESCRIPTION
## 주요 구현 사항 ✨
- issue: #47 
- 레이아웃 안에서 컴포넌트 반응형 UI 구현
- 공고 카드 리스트 그리드 구현
- 클래스 명 container -> wrap

## 스크린샷 🎨
![Jan-29-2024 12-54-12](https://github.com/sprintPart3Team4/the-julge/assets/148641571/8908564b-84a7-4e4d-919d-1e588927d939)

## 구체적 구현 사항 설명 📃
- `NoticeCardList` 컴포넌트: 각각 반응형 사이즈에 맞는 공고 카드 그리드 구현
- ShopPageLayout 컴포넌트에서 각 섹션을 section 태그로 감쌌고 section 태그에 마진을 정하는 방식으로 했습니다.
  - mobile, tablet에서는 양 옆 마진 값을 각각 1.2rem, 3.2rem으로 고정했고 컴포넌트 사이즈가 움직이도록 했고,
  - desktop 에서는 반대로 컴포넌트 사이즈는 고정하고 양 옆 마진 값은 auto로 지정해주었습니다.
- 각각의 자식 컴포넌트의 width는 부모인 레이아웃 컴포넌트의 section을 기준으로 100%로 잡고, 자식 컴포넌트에서는 고정된 너비를 지정하지 않도록 했습니다.

## 논의사항 🤔
- @Chyyni 전 일단 이렇게 해 보았습니다! 같이 얘기해보아요 ^~^
- 0기 분들 기준으로 이렇게 했는데 tablet -> desktop 반응형 브레이크포인트가 달라서 태블릿에서는 max-width를 지정해줘야 하나 싶네용
   - 이것도 채연님 같이 얘기 해보면 좋을 것 같습니다

