### PR TITLE
Feat: 공통 버튼 컴포넌트

### DIFF
--- a/components/common/button/Button.module.scss
+++ b/components/common/button/Button.module.scss
@@ -1,0 +1,83 @@
+@use "@/styles/variables.scss" as *;
+
+.button {
+  text-align: center;
+}
+
+@mixin basic {
+  // padding: 1.4rem 13.6rem;
+  width: 100%;
+  height: 4.8rem;
+  border-radius: 0.6rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 2rem;
+}
+
+@mixin maxWidth {
+  max-width: 35rem;
+}
+
+.flexible {
+  @include basic;
+}
+
+.fixed {
+  @include basic;
+  @include maxWidth;
+}
+
+.reactive {
+  padding: 1rem 2rem;
+  width: fit-content;
+  height: 3.7rem;
+  border-radius: 0.6rem;
+  font-size: 1.4rem;
+  font-weight: 700;
+  @include maxWidth;
+  @include tablet {
+    @include basic;
+  }
+}
+
+.checkModal {
+  // padding: 1.2rem 5.6rem;
+  width: 13.8rem;
+  height: 4.2rem;
+  border-radius: 0.8rem;
+  font-size: 1.4rem;
+  font-weight: 500;
+
+  @include tablet {
+    // padding: 1.4rem 4.6rem;
+    width: 12rem;
+    height: 4.8rem;
+    font-size: 1.6rem;
+  }
+}
+
+.yesOrNoModal {
+  // padding: 1rem 2rem;
+  width: 8rem;
+  height: 3.8rem;
+  border-radius: 0.6rem;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.primary {
+  background-color: $color-primary;
+  color: $color-white;
+}
+
+.secondary {
+  background-color: $color-white;
+  color: $color-primary;
+  border: 1px solid $color-primary;
+}
+
+.disabled:disabled {
+  background-color: $color-gray-40;
+  color: $color-white;
+  cursor: default;
+}

--- a/components/common/button/Button.tsx
+++ b/components/common/button/Button.tsx
@@ -1,0 +1,20 @@
+import { MouseEventHandler } from "react";
+import classNames from "classnames/bind";
+import styles from "./Button.module.scss";
+
+const cn = classNames.bind(styles);
+
+type Props = {
+  text: string;
+  size: "flexible" | "fixed" | "reactive" | "checkModal" | "yesOrNoModal";
+  color: "primary" | "secondary" | "disabled";
+  handleButtonClick?: MouseEventHandler<HTMLButtonElement>;
+};
+
+export default function Button({ text, size, color, handleButtonClick }: Props) {
+  return (
+    <button className={cn("button", size, color)} onClick={handleButtonClick} disabled={color === "disabled"}>
+      {text}
+    </button>
+  );
+}

--- a/components/common/checkButton/CheckButton.tsx
+++ b/components/common/checkButton/CheckButton.tsx
@@ -1,0 +1,5 @@
+import Button from "../button/Button";
+
+export default function CheckButton() {
+  return <Button text="확인" size="checkModal" color="primary" />;
+}

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -7,6 +7,7 @@ $color-gray-10: #f2f2f3;
 $color-gray-5: #fafafa;
 $color-white: #ffffff;
 
+$color-primary: #ea3c12;
 $color-red-40: #ff4040;
 $color-red-30: #ff8d72;
 $color-red-20: #ffaf9b;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -25,6 +25,9 @@ $breakpoint-mobile: 375px;
 $breakpoint-tablet: 744px;
 $breakpoint-pc: 1200px;
 
+$mobile-safezone: 1.2rem;
+$tablet-safezone: 3.2rem;
+
 @mixin mobile {
   @media (min-width: $breakpoint-mobile) {
     @content;


### PR DESCRIPTION
## 주요 구현 사항 ✨

- 공통 컴포넌트로 쓰이는 버튼 컴포넌트를 구현했습니다.
- varible.css 파일에 $color-primary 추가했습니다.(여기저기서 많이 쓰여서 이젠 무시할수가..ㅎ)
- 모달에 쓰이는 확인 버튼은 항상 같은 형태로 쓰이는 것 같아 이 버튼 컴포넌트를 이용해 또 따로 만들어놨습니다.

## 스크린샷 🎨

- 데스크탑 & 태블릿 사이즈에서

<img width="781" alt="스크린샷 2024-01-29 오후 1 16 20" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/d809f494-d625-409d-984b-b545b94d7ff4">
<div></div>
- 모바일 사이즈 진입 시
<div></div>
<img width="643" alt="스크린샷 2024-01-29 오후 1 16 35" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/7d759ba9-05fb-492b-9dab-f17dc3fc8c45">
<div></div>
거의 모바일 최소 사이즈에 가까워질 때
<div></div>
<img width="387" alt="스크린샷 2024-01-29 오후 1 16 51" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/deedcd91-067b-4628-80a0-5d0b4f3f79bc">


## 구체적 구현 사항 설명 📃
### Prop 설명

1. text: 버튼에 들어갈 text
2. size
- "flexible" : width가 100%로 항상 부모 크기를 따라갑니다.
-  "fixed" : width가 100%이지만, max-width가 350px로 고정입니다.
-  "reactive" : width가 100%이고, max-width가 350px로 고정되지만, 모바일에서는 text 크기만큼만 차지합니다.
-  "checkModal" : "확인"이라는 text를 쓰는 모달에서 사용합니다.
-  "yesOrNoModal" : "예" "아니오" 종류의 모달에서 사용합니다.
3. color
- "primary" : 주황색 배경과 하얀색 글씨를 입혀줍니다.
-  "secondary" : 하얀색 배경과 주황색 글씨&border를 입혀줍니다.
-  "disabled": "신청 불가"와 같이 버튼을 비활성화 시키면서, 회색 배경을 입혀줍니다.
4. handleButtonClick: optional로 지정해줬습니다.

## 논의사항 🤔

- 혹시 보시다가 어 이거 빠졌네 하는거 있으시면 말씀해주세요.
- 저번에 패딩값 때문에 골치였는데, 사실 생각해보니 패딩값을 주지 않아도 상관없는 것 같아 일단 주석처리 해놨습니다. (호옥옥옥시 필요해지면 다시 계산하러 피그마 보러가기 싫어서 일단 주석을 냅뒀어요.ㅎ)


