### PR TITLE
Feat: 공통/모달 컴포넌트

### DIFF
--- a/components/common/modal/Modal.module.scss
+++ b/components/common/modal/Modal.module.scss
@@ -1,0 +1,11 @@
+@use "@/styles/variables.scss" as *;
+
+.background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100vw;
+  background-color: rgba(0, 0, 0, 0.7);
+  z-index: 1;
+}

--- a/components/common/modal/Modal.tsx
+++ b/components/common/modal/Modal.tsx
@@ -1,0 +1,21 @@
+import React, { ReactNode } from "react";
+import classNames from "classnames/bind";
+import ConfirmModal from "./confirmModal/ConfirmModal";
+import WarningModal from "./warningModal/WarningModal";
+import YesOrNoModal from "./yesOrNoModal/YesOrNoModal";
+
+import styles from "./Modal.module.scss";
+
+const cn = classNames.bind(styles);
+
+type Props = {
+  children: ReactNode;
+};
+
+export default function Modal({ children }: Props) {
+  return <div className={cn("background")}>{children}</div>;
+}
+
+Modal.Confirm = ConfirmModal;
+Modal.Warning = WarningModal;
+Modal.YesOrNo = YesOrNoModal;

--- a/components/common/modal/confirmModal/ConfirmModal.module.scss
+++ b/components/common/modal/confirmModal/ConfirmModal.module.scss
@@ -1,0 +1,49 @@
+@use "@/styles/variables.scss" as *;
+
+.modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  padding: 0 2.8rem 2.8rem;
+
+  width: 32.7rem;
+  height: 22rem;
+
+  border-radius: 0.8rem;
+  background-color: $color-white;
+
+  @include tablet {
+    width: 54rem;
+    height: 25rem;
+  }
+}
+
+.text {
+  padding-top: 8.1rem;
+  text-align: center;
+
+  color: $color-modal-text;
+
+  font-size: 1.6rem;
+  font-weight: 500;
+
+  @include tablet {
+    padding-top: 10.8rem;
+    font-size: 1.8rem;
+  }
+}
+
+.buttonPosition {
+  display: flex;
+  justify-content: center;
+
+  @include tablet {
+    justify-content: flex-end;
+  }
+}

--- a/components/common/modal/confirmModal/ConfirmModal.tsx
+++ b/components/common/modal/confirmModal/ConfirmModal.tsx
@@ -1,0 +1,32 @@
+import { useRouter } from "next/router";
+import classNames from "classnames/bind";
+
+import Button from "../../button/Button";
+
+import styles from "./ConfirmModal.module.scss";
+
+const cn = classNames.bind(styles);
+
+type Props = {
+  text: string;
+  url: string;
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export default function ConfirmModal({ text, url, setIsModalOpen }: Props) {
+  const router = useRouter();
+
+  const handleButtonClick = () => {
+    setIsModalOpen(false);
+    router.push(url);
+  };
+
+  return (
+    <div className={cn("modal")}>
+      <p className={cn("text")}>{text}</p>
+      <div className={cn("buttonPosition")}>
+        <Button text="확인" size="checkModal" color="primary" handleButtonClick={handleButtonClick} />
+      </div>
+    </div>
+  );
+}

--- a/components/common/modal/warningModal/WarningModal.module.scss
+++ b/components/common/modal/warningModal/WarningModal.module.scss
@@ -1,0 +1,93 @@
+@use "@/styles/variables.scss" as *;
+
+@mixin textWrap {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+@mixin text {
+  text-align: center;
+  color: $color-modal-text;
+}
+
+.modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  border-radius: 0.8rem;
+  background-color: $color-white;
+}
+
+.normal {
+  padding: 2.8rem;
+
+  width: 32.7rem;
+  height: 22rem;
+
+  @include tablet {
+    width: 54rem;
+    height: 25rem;
+  }
+
+  .textWrap {
+    @include textWrap;
+    gap: 1.6rem;
+    padding-top: 2.4rem;
+
+    @include tablet {
+      padding-top: 4rem;
+    }
+  }
+
+  .text {
+    @include text;
+    font-size: 1.6rem;
+    font-weight: 500;
+
+    @include tablet {
+      font-size: 1.8rem;
+    }
+  }
+
+  .buttonPosition {
+    display: flex;
+    justify-content: center;
+
+    @include tablet {
+      justify-content: flex-end;
+    }
+  }
+}
+
+.small {
+  align-items: center;
+  padding: 2.4rem;
+
+  width: 29.8rem;
+  height: 18.4rem;
+
+  font-weight: 400;
+  line-height: 2.6rem;
+
+  .textWrap {
+    @include textWrap;
+    gap: 1.6rem;
+  }
+
+  .text {
+    @include text;
+    line-height: 2.6rem;
+  }
+
+  .buttonPosition {
+    width: 8rem;
+  }
+}

--- a/components/common/modal/warningModal/WarningModal.tsx
+++ b/components/common/modal/warningModal/WarningModal.tsx
@@ -1,0 +1,35 @@
+import classNames from "classnames/bind";
+import Button from "../../button/Button";
+import Warning from "@/public/images/warning.svg";
+
+import styles from "./WarningModal.module.scss";
+import Image from "next/image";
+
+const cn = classNames.bind(styles);
+
+type Props = {
+  size: "normal" | "small";
+  text: string;
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+// 만약 모달이 닫혔을 때, input의 value 값을 초기화하고 싶다는 등 handleButtonClick를 커스텀화하고 싶다면 수정 필요
+export default function WarningModal({ size, text, setIsModalOpen }: Props) {
+  const handleButtonClick = () => {
+    setIsModalOpen(false);
+  };
+
+  const buttonSize = size === "normal" ? "checkModal" : "yesOrNoModal";
+
+  return (
+    <div className={cn("modal", size)}>
+      <div className={cn("textWrap")}>
+        <Image src={Warning} alt="경고" width={24} height={24} />
+        <p className={cn("text")}>{text}</p>
+      </div>
+      <div className={cn("buttonPosition")}>
+        <Button text="확인" size={buttonSize} color="secondary" handleButtonClick={handleButtonClick} />
+      </div>
+    </div>
+  );
+}

--- a/components/common/modal/yesOrNoModal/YesOrNoModal.module.scss
+++ b/components/common/modal/yesOrNoModal/YesOrNoModal.module.scss
@@ -1,0 +1,41 @@
+@use "@/styles/variables.scss" as *;
+
+.modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 3.2rem;
+
+  padding: 2.4rem;
+
+  width: 29.8rem;
+  height: 18.4rem;
+
+  border-radius: 0.8rem;
+  background-color: $color-white;
+}
+
+.textWrap {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.6rem;
+}
+
+.text {
+  color: $color-modal-text;
+  line-height: 2.6rem;
+}
+
+.buttonPosition {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.8rem;
+}

--- a/components/common/modal/yesOrNoModal/YesOrNoModal.tsx
+++ b/components/common/modal/yesOrNoModal/YesOrNoModal.tsx
@@ -1,0 +1,36 @@
+import { MouseEventHandler } from "react";
+import Image from "next/image";
+import classNames from "classnames/bind";
+
+import Button from "../../button/Button";
+
+import Check from "@/public/images/check.svg";
+
+import styles from "./YesOrNoModal.module.scss";
+
+const cn = classNames.bind(styles);
+
+type Props = {
+  text: string;
+  yesButtonText: "취소하기" | "거절하기";
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  handleYesButtonClick: MouseEventHandler<HTMLButtonElement>;
+};
+
+export default function YesOrNoModal({ text, yesButtonText, setIsModalOpen, handleYesButtonClick }: Props) {
+  const handleNoButtonClick = () => {
+    setIsModalOpen(false);
+  };
+  return (
+    <div className={cn("modal")}>
+      <div className={cn("textWrap")}>
+        <Image src={Check} alt="경고" width={24} height={24} />
+        <p className={cn("text")}>{text}</p>
+      </div>
+      <div className={cn("buttonPosition")}>
+        <Button text="아니오" size="yesOrNoModal" color="secondary" handleButtonClick={handleNoButtonClick} />
+        <Button text={yesButtonText} size="yesOrNoModal" color="primary" handleButtonClick={handleYesButtonClick} />
+      </div>
+    </div>
+  );
+}

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -21,6 +21,8 @@ $color-green-10: #d4f7d4;
 
 $color-kakao: #fee500;
 
+$color-modal-text: #333236;
+
 $breakpoint-mobile: 375px;
 $breakpoint-tablet: 744px;
 $breakpoint-pc: 1200px;


### PR DESCRIPTION


## 주요 구현 사항 ✨

- 

## 스크린샷 🎨
- 단순 확인을 시켜주는모달 -> 확인을 누르면 prop으로 전달해 준 url로 이동!
<img width="597" alt="스크린샷 2024-01-29 오후 7 51 18" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/cbb508eb-2a5e-4ad2-9524-5c5727184436">
<img width="388" alt="스크린샷 2024-01-29 오후 7 51 25" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/756efccc-2041-4436-8e33-de0f7c2a4a9a">

<div></div>
- 경고 문구를 보여주는 모달 -> 확인을 누르면 모달이 닫힘.
<div></div>
<img width="385" alt="스크린샷 2024-01-29 오후 7 50 35" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/b8c7da02-9734-4c49-83c8-626cd9b27233">
<img width="351" alt="스크린샷 2024-01-29 오후 7 50 57" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/c61775e6-7ef5-4c58-b1fd-9a3303d9d474">

<div></div>
- "취소하기" 혹은 "거절하기" 를 누르거나 "아니오"를 누르는 모달 -> 아니오를 누르면 모달이 닫히기만 하고, 
- "취소하기" 혹은 "거절하기"를 누를 경우 동작하게 하는 함수는 handleYesButtonClick이라는 prop으로 전달해야 함
- "취소하기" 혹은 "거절하기"에 해당하는 text도 yesButtonText이라는 prop으로 전달해야 함
<div></div>
<img width="385" alt="스크린샷 2024-01-29 오후 7 50 03" src="https://github.com/sprintPart3Team4/the-julge/assets/141597336/5cf54b76-0078-4388-a585-11a5d074cb45">

## 구체적 구현 사항 설명 📃

- 대강의 컴포넌트 설명은 스크린샷과 함께 했습니다.
- 사용 시 Modal을 import 하고, 원하는 모달을 컴파운드 형태로 자식으로 전달하면 됩니다.
- 아래는 사용 예시 입니다.
```
    <div>
      {isModalOpen && (
        <Modal>
          <Modal.YesOrNo
            text="신청을 취소하시겠어요?"
            yesButtonText="취소하기"
            setIsModalOpen={setIsModalOpen}
            handleYesButtonClick={handleYesButtonClick}
          />
        </Modal>
      )}
    </div>
```

## 논의사항 🤔

- 가입이 완료되었습니다. 등록이 완료되었습니다. 같은 형태의 모달은 모달의 확인 버튼을 누르면 원하는 url로 이동하게 했습니다.
- 경고 문구를 보여주는 모달은 확인을 누르면 그냥 모달만 닫히도록 했고,
- 예/아니오를 선택하는 모달은 아니오를 누르면 모달이 닫히고, 예를 누르면 원하는 동작을 함수로 전달합니다.
- 위와 같이 구현했는데, 이견이 있으시다면 말씀해주세용
- 경고 문구를 보여주는 모달은 ! 아이콘과 버튼색 secondary로 통일했습니다.

