### PR TITLE
Feat: 공통/textarea 구현

### DIFF
--- a/components/common/textarea/Textarea.module.scss
+++ b/components/common/textarea/Textarea.module.scss
@@ -1,0 +1,39 @@
+@use "@/styles/variables.scss" as *;
+
+@mixin placeholder {
+  color: $color-gray-40;
+}
+
+.inputBox {
+  .title {
+    display: block;
+    margin-bottom: 0.8rem;
+    color: $color-black;
+    line-height: 2.6rem;
+  }
+
+  .desc {
+    resize: none;
+    outline: none;
+    width: 100%;
+    height: 15.3rem;
+    padding: 1.6rem 2rem;
+    border-radius: 0.6rem;
+    border: 1px solid $color-gray-30;
+    line-height: 2.6rem;
+    color: $color-black;
+
+    &::placeholder {
+      @include placeholder();
+    }
+  }
+}
+
+.inputBox.textarea {
+  width: 100%;
+  margin: 2rem 0 0;
+
+  @include desktop {
+    margin: 2.4rem 0 0;
+  }
+}

--- a/components/common/textarea/Textarea.tsx
+++ b/components/common/textarea/Textarea.tsx
@@ -1,0 +1,24 @@
+import classNames from "classnames/bind";
+import styles from "./Textarea.module.scss";
+
+const cn = classNames.bind(styles);
+
+export interface Textarea {
+  label: string;
+  title: string;
+  textarea: {
+    id: string;
+    name: string;
+  };
+}
+
+export default function Textarea({ label, title, textarea }: Textarea) {
+  return (
+    <div className={cn("inputBox", "textarea")}>
+      <label htmlFor={label} className={cn("title")}>
+        {title}
+      </label>
+      <textarea {...textarea} className={cn("desc")} placeholder="입력"></textarea>
+    </div>
+  );
+}


### PR DESCRIPTION
## 주요 구현 사항 ✨

- textarea를 공통으로 분리했습니다

## 스크린샷 🎨

![localhost_3000_ (11) (1)](https://github.com/sprintPart3Team4/the-julge/assets/94034865/2667bcc1-d164-40cb-9e1b-e7d0bd09d5f0)

## 구체적 구현 사항 설명 📃

- 사용예시
```
 <Textarea
  label="description"
  title="가게 설명"
  textarea={{
    id: "description",
    name: "description",
  }}
/>
```

## 논의사항 🤔

-

