### PR TITLE
Design: 공통/네비게이션 바-UI 구현 및 전역으로 추가

### DIFF
--- a/components/common/navBar/NavBar.module.scss
+++ b/components/common/navBar/NavBar.module.scss
@@ -1,0 +1,107 @@
+@use "@/styles/variables.scss" as *;
+
+.wrap {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: grid;
+  grid-template-areas:
+    "logo buttons"
+    "search search";
+  grid-template-rows: 3rem;
+  align-items: center;
+  gap: 1.6rem;
+  padding: 1rem 2rem;
+  background-color: $color-white;
+  z-index: 1;
+
+  @include tablet {
+    grid-template-areas: "logo search buttons";
+    grid-template-columns: 10.8rem auto 17rem;
+    gap: 2.2rem;
+    padding: 1.5rem 3.2rem;
+  }
+
+  @include desktop {
+    grid-template-columns: 10.8rem auto 22.6rem;
+    gap: 5.3rem;
+    padding: 1.5rem calc((100% - 102.4rem) / 2);
+    box-sizing: content-box;
+    width: 102.4rem;
+  }
+}
+
+.logo {
+  grid-area: logo;
+  display: flex;
+  align-items: center;
+}
+
+.buttons {
+  grid-area: buttons;
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+  @include tablet {
+    gap: 1.2rem;
+  }
+  @include desktop {
+    gap: 4rem;
+  }
+
+  .button {
+    color: $color-black;
+    font-size: 1.4rem;
+    font-weight: 700;
+    text-decoration: none;
+    @include tablet {
+      font-size: 1.6rem;
+      line-height: 2rem;
+    }
+  }
+  .icon {
+    @include tablet {
+      width: 2.4rem;
+      height: 2.4rem;
+    }
+  }
+}
+
+.searchBar {
+  grid-area: search;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  width: 100%;
+  height: 3.6rem;
+  border-radius: 10px;
+  background: $color-gray-10;
+  @include tablet {
+    height: 4rem;
+  }
+  @include desktop {
+    width: 45rem;
+  }
+
+  input {
+    flex-direction: column;
+    flex-grow: 1;
+    outline: none;
+    border: none;
+    background-color: transparent;
+    color: $color-black;
+    font-size: 1.2rem;
+    line-height: 1.6rem;
+    @include tablet {
+      font-size: 1.4rem;
+      line-height: 2.2rem;
+    }
+
+    &::placeholder {
+      color: $color-gray-40;
+    }
+  }
+}

--- a/components/common/navBar/NavBar.tsx
+++ b/components/common/navBar/NavBar.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Logo from "../logo/Logo";
+import styles from "./NavBar.module.scss";
+import classNames from "classnames/bind";
+import Link from "next/link";
+import SearchIcon from "@/public/images/search.svg";
+import Image from "next/image";
+import ActiveNotificationIcon from "@/public/images/notification_active.svg";
+import InactiveNotificationIcon from "@/public/images/notification_inactive.svg";
+
+const cn = classNames.bind(styles);
+
+export default function NavBar() {
+  return (
+    <nav className={cn("wrap")}>
+      <div className={cn("logo")}>
+        <Logo />
+      </div>
+      <div className={cn("searchBar")}>
+        <Image className={cn("icon")} src={SearchIcon} alt="돋보기 아이콘" width={16} height={16} />
+        <input type="text" placeholder="가게 이름으로 찾아보세요" />
+      </div>
+      <div className={cn("buttons")}>
+        <Link href={"/signin"} className={cn("button")}>
+          내 프로필
+        </Link>
+        <Link href={"/signin"} className={cn("button")}>
+          로그아웃
+        </Link>
+        <Image className={cn("icon")} src={InactiveNotificationIcon} alt="알림 아이콘" width={17} height={17} />
+      </div>
+    </nav>
+  );
+}

--- a/components/common/navBar/NavBar.tsx
+++ b/components/common/navBar/NavBar.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import Logo from "../logo/Logo";
-import styles from "./NavBar.module.scss";
 import classNames from "classnames/bind";
-import Link from "next/link";
-import SearchIcon from "@/public/images/search.svg";
 import Image from "next/image";
+import Link from "next/link";
+import Logo from "../logo/Logo";
+import SearchIcon from "@/public/images/search.svg";
 import ActiveNotificationIcon from "@/public/images/notification_active.svg";
 import InactiveNotificationIcon from "@/public/images/notification_inactive.svg";
+import styles from "./NavBar.module.scss";
 
 const cn = classNames.bind(styles);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,12 @@
 import type { AppProps } from "next/app";
 import { AuthProvider } from "@/contexts/AuthProvider";
+import NavBar from "@/components/common/navBar/NavBar";
 import "@/styles/global.scss";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider>
+      <NavBar />
       <Component {...pageProps} />
     </AuthProvider>
   );

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -16,8 +16,13 @@ html {
 }
 
 body {
+  margin-top: 10.2rem;
   font-size: 1.6rem;
   color: $color-black;
+
+  @include tablet {
+    margin-top: 6rem;
+  }
 }
 
 @font-face {


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 글로벌 네비게이션 바 UI 작업 (반응형 포함)

## 스크린샷 🎨
![Feb-03-2024 18-24-07](https://github.com/sprintPart3Team4/the-julge/assets/148641571/e47a8917-b601-445f-a6cb-4459b076815b)


## 구체적 구현 사항 설명 📃
- UI만 먼저 작업한 거라 스크린샷 참고해주세요.

## 논의사항 🤔

- 영은님 만드신 네비게이션 바가 있어서 영은님께 파일 받아서 UI 먼저 작업했습니다.
- 모든 페이지에 공통적으로 들어가는 부분이라 _app.tsx 파일 상단에 네비게이션바 컴포넌트 넣어두었습니다.
- position: fixed로 작업해서 네비게이션 바 높이만큼 global.scss 파일에 전역 margin-top 값 설정해두었습니다.
- 스크롤 하면서 매번 상단에 보여지는 게 그닥 예뻐보이지는 않아서 스크롤을 내릴 땐 안 보이게 하고 스크롤을 올릴 때 보여지는 식으로 나중에 구현해보면 어떨까 싶습니다.

