### PR TITLE
Feat: 신청자 목록 구현

### DIFF
--- a/components/shopNoticePage/applications/Application.tsx
+++ b/components/shopNoticePage/applications/Application.tsx
@@ -1,0 +1,36 @@
+import classNames from "classnames/bind";
+import StatusButton from "../statusButton/StatusButton";
+import StatusBadge from "../statusBadge/StatusBadge";
+
+import styles from "./Applications.module.scss";
+
+const cn = classNames.bind(styles);
+
+type Props = {
+  name?: string;
+  bio?: string;
+  phone?: string;
+  status: "pending" | "accepted" | "rejected" | "canceled";
+};
+
+export default function Application({ name, bio, phone, status }: Props) {
+  return (
+    <tr className={cn("tr")}>
+      <td className={cn("td", "name")}>{name}</td>
+      <td className={cn("td", "bio")}>
+        <div className={cn("bioLineUp")}>{bio}</div>
+      </td>
+      <td className={cn("td", "phone")}>{phone}</td>
+      <td className={cn("td", "status")}>
+        {status === "pending" ? (
+          <div className={cn("statusButtons")}>
+            <StatusButton status="rejected" text="거절하기" />
+            <StatusButton status="accepted" text="승인하기" />
+          </div>
+        ) : (
+          <StatusBadge status={status} />
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/components/shopNoticePage/applications/Application.tsx
+++ b/components/shopNoticePage/applications/Application.tsx
@@ -7,13 +7,14 @@ import styles from "./Applications.module.scss";
 const cn = classNames.bind(styles);
 
 type Props = {
+  applicationId: string;
   name?: string;
   bio?: string;
   phone?: string;
   status: "pending" | "accepted" | "rejected" | "canceled";
 };
 
-export default function Application({ name, bio, phone, status }: Props) {
+export default function Application({ applicationId, name, bio, phone, status }: Props) {
   return (
     <tr className={cn("tr")}>
       <td className={cn("td", "name")}>{name}</td>
@@ -24,8 +25,8 @@ export default function Application({ name, bio, phone, status }: Props) {
       <td className={cn("td", "status")}>
         {status === "pending" ? (
           <div className={cn("statusButtons")}>
-            <StatusButton status="rejected" text="거절하기" />
-            <StatusButton status="accepted" text="승인하기" />
+            <StatusButton status="rejected" text="거절하기" applicationId={applicationId} />
+            <StatusButton status="accepted" text="승인하기" applicationId={applicationId} />
           </div>
         ) : (
           <StatusBadge status={status} />

--- a/components/shopNoticePage/applications/Applications.module.scss
+++ b/components/shopNoticePage/applications/Applications.module.scss
@@ -1,0 +1,130 @@
+@use "@/styles/variables.scss" as *;
+
+.wrap {
+  margin: 2rem;
+  border: 1px solid $color-gray-20;
+  border-radius: 1rem;
+
+  @include desktop {
+    width: 96.4rem;
+  }
+}
+
+.tableWrap {
+  overflow-x: scroll;
+  -ms-overflow-style: none;
+
+  @include desktop {
+    overflow-x: hidden;
+  }
+}
+
+.tableWrap::-webkit-scrollbar {
+  display: none;
+}
+
+.table {
+  table-layout: fixed;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.tbody {
+  border: none;
+}
+
+.th {
+  padding: 0.8rem;
+  background-color: $color-red-10;
+  color: $color-black;
+
+  font-size: 1.2rem;
+  font-weight: 400;
+  line-height: 1.6rem;
+
+  text-align: start;
+
+  @include tablet {
+    padding: 2rem 1.2rem;
+    font-size: 1.4rem;
+    line-height: 2.2rem;
+  }
+}
+
+.tr {
+  border-bottom: 1px solid $color-gray-10;
+}
+
+.td {
+  padding: 0.8rem;
+
+  color: $color-black;
+
+  font-size: 1.4rem;
+  line-height: 2.2rem;
+
+  text-align: start;
+
+  &.name {
+    background-color: $color-white;
+  }
+
+  @include tablet {
+    padding: 2rem 1.2rem;
+    font-size: 1.6rem;
+    line-height: 2.6rem;
+  }
+}
+
+.name {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
+
+.bioLineUp {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  @include tablet {
+    -webkit-line-clamp: 2;
+  }
+}
+
+.bio,
+.phone,
+.status {
+  // width 값 지정?
+}
+
+.statusButtons {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  @include tablet {
+    gap: 1.2rem;
+  }
+}
+
+.pagenationWrap {
+  display: contents;
+  justify-content: center;
+  align-items: center;
+
+  border: 1px solid $color-gray-20;
+  border-radius: 1rem;
+}
+
+.pagenation {
+  height: 5.6rem;
+  text-align: center;
+
+  @include tablet {
+    height: 6.4rem;
+  }
+}

--- a/components/shopNoticePage/applications/Applications.module.scss
+++ b/components/shopNoticePage/applications/Applications.module.scss
@@ -1,15 +1,5 @@
 @use "@/styles/variables.scss" as *;
 
-.wrap {
-  margin: 2rem;
-  border: 1px solid $color-gray-20;
-  border-radius: 1rem;
-
-  @include desktop {
-    width: 96.4rem;
-  }
-}
-
 .tableWrap {
   overflow-x: scroll;
   -ms-overflow-style: none;
@@ -108,23 +98,5 @@
 
   @include tablet {
     gap: 1.2rem;
-  }
-}
-
-.pagenationWrap {
-  display: contents;
-  justify-content: center;
-  align-items: center;
-
-  border: 1px solid $color-gray-20;
-  border-radius: 1rem;
-}
-
-.pagenation {
-  height: 5.6rem;
-  text-align: center;
-
-  @include tablet {
-    height: 6.4rem;
   }
 }

--- a/components/shopNoticePage/applications/Applications.tsx
+++ b/components/shopNoticePage/applications/Applications.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames/bind";
 import Application from "./Application";
 import styles from "./Applications.module.scss";
+import { ApplicationList } from "@/types/apiTypes";
 
 const cn = classNames.bind(styles);
 
@@ -14,57 +15,44 @@ type Application = {
   };
 };
 
-const applicant1: Application = {
-  id: "1",
-  status: "pending",
-  user: {
-    name: "김강현",
-    bio: "최선을 다해 열심히 일합니다. 다수의 업무 경험을 바탕으로 확실한 일처리를 보여드리겠습니다. 감사합니다.",
-    phone: "010-0000-0000",
-  },
+type Props = {
+  applicationList: ApplicationList;
 };
 
-const applicant2: Application = {
-  id: "2",
-  status: "pending",
-  user: {
-    name: "김강현",
-    bio: "최선을 다해 열심히 일합니다. 다수의 업무 경험을 바탕으로 확실한 일처리를 보여드리겠습니다. 감사합니다.",
-    phone: "010-0000-0000",
-  },
-};
-
-const applicants = [applicant1, applicant2];
-
-export default function Applications() {
+export default function Applications({ applicationList }: Props) {
   return (
-    <div className={cn("wrap")}>
-      <div className={cn("tableWrap")}>
-        <table className={cn("table")}>
-          <colgroup>
-            <col style={{ width: "22.8rem" }} />
-            <col style={{ width: "30rem" }} />
-            <col style={{ width: "20rem" }} />
-            <col style={{ width: "23.6rem" }} />
-          </colgroup>
-          <thead>
-            <tr className={cn("tr")}>
-              <th className={cn("th", "name")}>지원자</th>
-              <th className={cn("th", "bio")}>소개</th>
-              <th className={cn("th", "phone")}>전화번호</th>
-              <th className={cn("th", "status")}>상태</th>
-            </tr>
-          </thead>
-          <tbody className={cn("tbody")}>
-            {applicants.map(({ id, status, user: { name, bio, phone } }) => (
-              <Application key={id} status={status} name={name} bio={bio} phone={phone} />
-            ))}
-          </tbody>
-        </table>
-      </div>
-      <div className={cn("pagenationWrap")}>
-        <div className={cn("pagenation")}>페이지네이션</div>
-      </div>
+    <div className={cn("tableWrap")}>
+      <table className={cn("table")}>
+        <colgroup>
+          <col style={{ width: "22.8rem" }} />
+          <col style={{ width: "30rem" }} />
+          <col style={{ width: "20rem" }} />
+          <col style={{ width: "23.6rem" }} />
+        </colgroup>
+        <thead>
+          <tr className={cn("tr")}>
+            <th className={cn("th", "name")}>지원자</th>
+            <th className={cn("th", "bio")}>소개</th>
+            <th className={cn("th", "phone")}>전화번호</th>
+            <th className={cn("th", "status")}>상태</th>
+          </tr>
+        </thead>
+        <tbody className={cn("tbody")}>
+          {applicationList.map(
+            ({
+              item: {
+                id,
+                status,
+                user: {
+                  item: { name, bio, phone },
+                },
+              },
+            }) => (
+              <Application key={id} applicationId={id} status={status} name={name} bio={bio} phone={phone} />
+            )
+          )}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/components/shopNoticePage/applications/Applications.tsx
+++ b/components/shopNoticePage/applications/Applications.tsx
@@ -1,0 +1,70 @@
+import classNames from "classnames/bind";
+import Application from "./Application";
+import styles from "./Applications.module.scss";
+
+const cn = classNames.bind(styles);
+
+type Application = {
+  id: string;
+  status: "pending" | "accepted" | "rejected" | "canceled";
+  user: {
+    name?: string;
+    bio?: string;
+    phone?: string;
+  };
+};
+
+const applicant1: Application = {
+  id: "1",
+  status: "pending",
+  user: {
+    name: "김강현",
+    bio: "최선을 다해 열심히 일합니다. 다수의 업무 경험을 바탕으로 확실한 일처리를 보여드리겠습니다. 감사합니다.",
+    phone: "010-0000-0000",
+  },
+};
+
+const applicant2: Application = {
+  id: "2",
+  status: "pending",
+  user: {
+    name: "김강현",
+    bio: "최선을 다해 열심히 일합니다. 다수의 업무 경험을 바탕으로 확실한 일처리를 보여드리겠습니다. 감사합니다.",
+    phone: "010-0000-0000",
+  },
+};
+
+const applicants = [applicant1, applicant2];
+
+export default function Applications() {
+  return (
+    <div className={cn("wrap")}>
+      <div className={cn("tableWrap")}>
+        <table className={cn("table")}>
+          <colgroup>
+            <col style={{ width: "22.8rem" }} />
+            <col style={{ width: "30rem" }} />
+            <col style={{ width: "20rem" }} />
+            <col style={{ width: "23.6rem" }} />
+          </colgroup>
+          <thead>
+            <tr className={cn("tr")}>
+              <th className={cn("th", "name")}>지원자</th>
+              <th className={cn("th", "bio")}>소개</th>
+              <th className={cn("th", "phone")}>전화번호</th>
+              <th className={cn("th", "status")}>상태</th>
+            </tr>
+          </thead>
+          <tbody className={cn("tbody")}>
+            {applicants.map(({ id, status, user: { name, bio, phone } }) => (
+              <Application key={id} status={status} name={name} bio={bio} phone={phone} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className={cn("pagenationWrap")}>
+        <div className={cn("pagenation")}>페이지네이션</div>
+      </div>
+    </div>
+  );
+}

--- a/components/shopNoticePage/statusBadge/StatusBadge.tsx
+++ b/components/shopNoticePage/statusBadge/StatusBadge.tsx
@@ -1,0 +1,35 @@
+import classNames from "classnames/bind";
+import styles from "./StatusBadge.module.scss";
+
+const cn = classNames.bind(styles);
+
+type Status = "pending" | "accepted" | "rejected" | "canceled";
+
+type Props = {
+  status: Status;
+};
+
+export default function StatusBadge({ status }: Props) {
+  const badgeName = getBadgeName(status);
+  return <div className={cn("badge", status)}>{badgeName}</div>;
+}
+
+function getBadgeName(status: Status) {
+  switch (status) {
+    case "pending":
+      return "대기 중";
+
+    case "accepted":
+      return "승인 완료";
+
+    case "rejected":
+      return "거절";
+
+    case "canceled":
+      return "지원 취소";
+
+    default:
+      const invalid: never = status;
+      throw new Error(`unknown Status: ${invalid}`);
+  }
+}

--- a/components/shopNoticePage/statusBadge/statusBadge.module.scss
+++ b/components/shopNoticePage/statusBadge/statusBadge.module.scss
@@ -1,0 +1,40 @@
+@use "@/styles/variables.scss" as *;
+
+.badge {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  padding: 0.6rem 1rem;
+  border-radius: 2rem;
+
+  width: fit-content;
+  white-space: nowrap;
+
+  font-size: 1.2rem;
+  line-height: 1.6rem;
+
+  @include tablet {
+    padding: 1rem 2rem;
+
+    font-size: 1.4rem;
+    font-weight: 700;
+    line-height: normal;
+  }
+}
+
+.pending {
+  color: $color-green-20;
+  background-color: $color-green-10;
+}
+
+.accepted {
+  color: $color-blue-20;
+  background-color: $color-blue-10;
+}
+
+.rejected,
+.canceled {
+  color: $color-red-40;
+  background-color: $color-red-10;
+}

--- a/components/shopNoticePage/statusButton/StatusButton.module.scss
+++ b/components/shopNoticePage/statusButton/StatusButton.module.scss
@@ -1,0 +1,30 @@
+@use "@/styles/variables.scss" as *;
+
+.button {
+  padding: 0.8rem 1.2rem;
+  border-radius: 0.6rem;
+
+  font-size: 1.2rem;
+  line-height: 1.6rem;
+
+  text-align: center;
+  white-space: nowrap;
+
+  @include tablet {
+    padding: 1rem 2rem;
+
+    font-size: 1.4rem;
+    font-weight: 700;
+    line-height: normal;
+  }
+}
+
+.accepted {
+  color: $color-blue-20;
+  border: 1px solid $color-blue-20;
+}
+
+.rejected {
+  color: $color-red-40;
+  border: 1px solid $color-red-40;
+}

--- a/components/shopNoticePage/statusButton/StatusButton.tsx
+++ b/components/shopNoticePage/statusButton/StatusButton.tsx
@@ -1,0 +1,25 @@
+import classNames from "classnames/bind";
+import styles from "./StatusButton.module.scss";
+import { useState } from "react";
+
+const cn = classNames.bind(styles);
+
+type Props = {
+  status: "accepted" | "rejected";
+  text: "승인하기" | "거절하기";
+};
+
+export default function StatusButton({ status, text }: Props) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleModalOpen = () => setIsModalOpen(true);
+  return (
+    <div>
+      <button className={cn("button", status)} onClick={handleModalOpen}>
+        {text}
+      </button>
+      {/* todo: 모달 만든 후, 버튼을 누르면 모달이 열리고 -> 모달에서 네/아니오 버튼을 누르면 해당 status로 변경되도록 구현 */}
+      {isModalOpen && <div>{isModalOpen}</div>}
+    </div>
+  );
+}

--- a/components/shopNoticePage/statusButton/StatusButton.tsx
+++ b/components/shopNoticePage/statusButton/StatusButton.tsx
@@ -1,25 +1,69 @@
 import classNames from "classnames/bind";
 import styles from "./StatusButton.module.scss";
 import { useState } from "react";
+import Modal from "@/components/common/modal/Modal";
+import { useRouter } from "next/router";
+import getCookies from "@/lib/getCookies";
+import instance from "@/lib/axiosInstance";
 
 const cn = classNames.bind(styles);
 
 type Props = {
   status: "accepted" | "rejected";
   text: "승인하기" | "거절하기";
+  applicationId: string;
 };
 
-export default function StatusButton({ status, text }: Props) {
+export default function StatusButton({ status, text, applicationId }: Props) {
+  const router = useRouter();
+  const { noticeId } = router.query;
+
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  const modalText = text === "승인하기" ? "신청을 승인하시겠어요?" : "신청을 거절하시겠어요?";
+
+  if (typeof noticeId !== "string") {
+    return;
+  }
+
   const handleModalOpen = () => setIsModalOpen(true);
+
+  const handleChangeStatus = () => {
+    changeStatus(noticeId, applicationId, status);
+    setIsModalOpen(false);
+    // 일단 리로드 함수를 썼는데... 다른 방법이 있나 나중에 찾아봐야 함..
+    router.reload();
+  };
+
   return (
     <div>
       <button className={cn("button", status)} onClick={handleModalOpen}>
         {text}
       </button>
-      {/* todo: 모달 만든 후, 버튼을 누르면 모달이 열리고 -> 모달에서 네/아니오 버튼을 누르면 해당 status로 변경되도록 구현 */}
-      {isModalOpen && <div>{isModalOpen}</div>}
+      {isModalOpen && (
+        <Modal>
+          <Modal.YesOrNo
+            text={modalText}
+            yesButtonText={text}
+            setIsModalOpen={setIsModalOpen}
+            handleYesButtonClick={handleChangeStatus}
+          />
+        </Modal>
+      )}
     </div>
   );
 }
+
+const changeStatus = async (noticeId: string, applicationId: string, status: "accepted" | "rejected") => {
+  const { shopId, token } = getCookies();
+
+  await instance.put(
+    `shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
+    {
+      status: status,
+    },
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+};

--- a/pages/shop/[id].tsx
+++ b/pages/shop/[id].tsx
@@ -1,1 +1,10 @@
+import Applications from "@/components/shopNoticePage/applications/Applications";
+
 // 사장님 공고 상세 페이지 - 채연
+export default function NoticeDetailPage() {
+  return (
+    <div>
+      <Applications />
+    </div>
+  );
+}


### PR DESCRIPTION
## 주요 구현 사항 ✨

- 신청자 목록 UI와 API를 구현하였습니다.
- UI 부분을 pr을 따로 올렸다고 생각했는데, 아니었어서 파일 크기가 또 커졌습니다. 필요한 부분 위주로 comment 남겨 놓을 게요.

## 스크린샷 🎨

- 스크린샷을 못 찍었어요.. 죄송해요..

## 구체적 구현 사항 설명 📃

- table을 이용하여 구현하였습니다.
- Applications 컴포넌트는 전체적인 테이블의 구조를 나타냅니다. 
- Application은 한 명의 지원자를 보여주는 하나의 행을 나타냅니다.
- 부모 컴포넌트인 Applications에서 map 함수를 통해 페이지 단위 컴포넌트에서 prop으로 내려받은 Application의 개수만큼 행을 만들어냅니다.
- 지원자가 아직 대기 중(pending)일 때는 StatusButton을 두 개 보여주고(거절하기, 승인하기)
- 지원자가 거절 혹은 승인이 완료된 상태라면 그 상태에 맞는 statusBadge를 보여줍니다.

## 논의사항 🤔

- 스크린샷을 찍을 수 없는 상태라 파일이 합쳐진 후에 보여드리면서 말씀드려야 겠지만, 신청자 목록 테이블에 헤더 부분이 overflow 되고 있는 부분을 hidden 시키지 못하고 있습니다.

