### PR TITLE
Feat: 공통/gnb-로그인 여부에 따른 버튼 및 토글 기능

### DIFF
--- a/components/common/navBar/NavBar.module.scss
+++ b/components/common/navBar/NavBar.module.scss
@@ -18,13 +18,13 @@
 
   @include tablet {
     grid-template-areas: "logo search buttons";
-    grid-template-columns: 10.8rem auto 17rem;
+    grid-template-columns: 10.8rem auto 20rem;
     gap: 2.2rem;
     padding: 1.5rem 3.2rem;
   }
 
   @include desktop {
-    grid-template-columns: 10.8rem auto 22.6rem;
+    grid-template-columns: 10.8rem auto 25rem;
     gap: 5.3rem;
     padding: 1.5rem calc((100% - 102.4rem) / 2);
     box-sizing: content-box;
@@ -45,6 +45,7 @@
   align-items: center;
   gap: 1.6rem;
   @include tablet {
+    position: relative;
     gap: 1.2rem;
   }
   @include desktop {
@@ -52,6 +53,8 @@
   }
 
   .button {
+    display: flex;
+    align-items: center;
     color: $color-black;
     font-size: 1.4rem;
     font-weight: 700;
@@ -65,6 +68,18 @@
     @include tablet {
       width: 2.4rem;
       height: 2.4rem;
+    }
+  }
+
+  .notification {
+    position: absolute;
+    inset: 0;
+    @include tablet {
+      top: 3.5rem;
+      left: -18.5rem;
+    }
+    @include desktop {
+      left: -12.7rem;
     }
   }
 }

--- a/components/common/navBar/NavBar.tsx
+++ b/components/common/navBar/NavBar.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { MouseEventHandler, useState } from "react";
 import classNames from "classnames/bind";
 import Image from "next/image";
 import Link from "next/link";
 import Logo from "../logo/Logo";
+import NotificationList from "./notificationList/NotificationList";
+import { useAuth } from "@/contexts/AuthProvider";
 import SearchIcon from "@/public/images/search.svg";
 import ActiveNotificationIcon from "@/public/images/notification_active.svg";
 import InactiveNotificationIcon from "@/public/images/notification_inactive.svg";
@@ -11,24 +13,51 @@ import styles from "./NavBar.module.scss";
 const cn = classNames.bind(styles);
 
 export default function NavBar() {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const { user } = useAuth();
+
+  const handleToggleNotification = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    setIsOpen(!isOpen);
+  };
+
   return (
     <nav className={cn("wrap")}>
       <div className={cn("logo")}>
-        <Logo />
+        <Link href={"/"}>
+          <Logo />
+        </Link>
       </div>
       <div className={cn("searchBar")}>
         <Image className={cn("icon")} src={SearchIcon} alt="돋보기 아이콘" width={16} height={16} />
         <input type="text" placeholder="가게 이름으로 찾아보세요" />
       </div>
-      <div className={cn("buttons")}>
-        <Link href={"/signin"} className={cn("button")}>
-          내 프로필
-        </Link>
-        <Link href={"/signin"} className={cn("button")}>
-          로그아웃
-        </Link>
-        <Image className={cn("icon")} src={InactiveNotificationIcon} alt="알림 아이콘" width={17} height={17} />
-      </div>
+      {user ? (
+        <div className={cn("buttons")}>
+          <Link href={"/profile"} className={cn("button")}>
+            내 프로필
+          </Link>
+          <button type="button" className={cn("button")}>
+            로그아웃
+          </button>
+          <button type="button" className={cn("button")} onClick={handleToggleNotification}>
+            <Image className={cn("icon")} src={InactiveNotificationIcon} alt="알림 아이콘" width={17} height={17} />
+          </button>
+          {isOpen && (
+            <div className={cn("notification")}>
+              <NotificationList />
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className={cn("buttons")}>
+          <Link href={"/signin"} className={cn("button")}>
+            로그인
+          </Link>
+          <Link href={"/signup"} className={cn("button")}>
+            회원가입
+          </Link>
+        </div>
+      )}
     </nav>
   );
 }

--- a/components/common/navBar/NavBar.tsx
+++ b/components/common/navBar/NavBar.tsx
@@ -44,7 +44,7 @@ export default function NavBar() {
           </button>
           {isOpen && (
             <div className={cn("notification")}>
-              <NotificationList />
+              <NotificationList isOpen={isOpen} setIsOpen={setIsOpen} />
             </div>
           )}
         </div>

--- a/components/common/navBar/NavBar.tsx
+++ b/components/common/navBar/NavBar.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, useState } from "react";
+import React, { useState } from "react";
 import classNames from "classnames/bind";
 import Image from "next/image";
 import Link from "next/link";
@@ -14,7 +14,7 @@ const cn = classNames.bind(styles);
 
 export default function NavBar() {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
 
   const handleToggleNotification = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     setIsOpen(!isOpen);
@@ -36,7 +36,7 @@ export default function NavBar() {
           <Link href={"/profile"} className={cn("button")}>
             내 프로필
           </Link>
-          <button type="button" className={cn("button")}>
+          <button type="button" className={cn("button")} onClick={logout}>
             로그아웃
           </button>
           <button type="button" className={cn("button")} onClick={handleToggleNotification}>

--- a/components/common/navBar/notificationList/NotificationList.module.scss
+++ b/components/common/navBar/notificationList/NotificationList.module.scss
@@ -5,18 +5,13 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 1.6rem;
-  margin-top: -10.2rem;
   padding: 4rem 2rem;
   width: 100vw;
   height: 100vh;
   background-color: $color-red-10;
 
   @include tablet {
-    position: absolute;
-    right: 3.2rem;
-    top: 5.6rem;
     padding: 2.4rem 2rem;
-    margin-top: 6rem; // 이건 수정 필요
     width: fit-content;
     height: fit-content;
     border-radius: 10px;

--- a/components/common/navBar/notificationList/NotificationList.tsx
+++ b/components/common/navBar/notificationList/NotificationList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import classNames from "classnames/bind";
 import { useMediaQuery } from "react-responsive";
 import Image from "next/image";
@@ -8,16 +8,29 @@ import styles from "./NotificationList.module.scss";
 
 const cn = classNames.bind(styles);
 
-export default function NotificationList() {
+type Props = {
+  isOpen: boolean;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+export default function NotificationList({ isOpen, setIsOpen }: Props) {
   const isMobile: boolean = useMediaQuery({
     query: "(max-width:743px)",
   });
+
+  const closeNotification = () => {
+    setIsOpen(false);
+  };
 
   return (
     <div className={cn("wrap")}>
       <div className={cn("title")}>
         <h2>알림 6개</h2>
-        {isMobile && <Image src={CloseIcon} alt="창 닫기 아이콘" width={24} height={24} />}
+        {isMobile && isOpen && (
+          <button type="button" onClick={closeNotification}>
+            <Image src={CloseIcon} alt="창 닫기 아이콘" width={24} height={24} />
+          </button>
+        )}
       </div>
       <ul className={cn("list")}>
         <li>


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 어제 올렸던 PR과 동일한 내용인데 로그아웃 기능만 추가 되었습니다. (제가 로컬에서 프로젝트 삭제하고 다시 클론해오면서 PR 내용이 날아갔던 것 같아요..? 그래서 다시 작업해서 올립니다 ㅎㅎ)
- 로그인 여부에 따라 다르게 보여지는 네비게이션 바 버튼
- 알림창 아이콘 클릭 시 토글 되도록
- 로그아웃 버튼 클릭 시 로그아웃 됨

## 스크린샷 🎨
### 로그인 전 (유저 정보 없을 시)
![image](https://github.com/sprintPart3Team4/the-julge/assets/148641571/81a2ef30-fbd4-41ef-9425-17a9caff7f49)
### 로그인 후 (유저 정보 있을 시)
![image](https://github.com/sprintPart3Team4/the-julge/assets/148641571/5b0e6be2-eb19-4805-8395-5fc856f15453)
### 알림창 아이콘 클릭 시 토글
![Feb-05-2024 10-18-58](https://github.com/sprintPart3Team4/the-julge/assets/148641571/7b0eecd1-a173-41e0-a27b-9bfb7f245782)

## 구체적 구현 사항 설명 📃

- 유저 정보는 useAuth 훅을 사용하여 받아온 후 로그인 여부를 확인합니다.
- 로그아웃 기능은 useAuth의 logout 함수를 이용합니다.
```tsx
const { user, logout } = useAuth();
```

## 논의사항 🤔
- 알림창 요소 바깥 부분 클릭 시 닫히도록 구현한 후 PR 올리려고 했으나 일단 다른 것들을 빨리 끝내야 할 것 같아 그 부분은 일단 나중에 해보겠습니다 ㅎ.ㅎ


