### PR TITLE
공고조회

### DIFF
--- a/components/Notices/sortDropBox/SortDropBox.tsx
+++ b/components/Notices/sortDropBox/SortDropBox.tsx
@@ -27,7 +27,7 @@ export default function SortDropBox({ list, selectedItem, handleSortButtonClick 
   const handleDropBoxBlur = () => {
     setTimeout(() => {
       setIsDropBoxOpen(false);
-    }, 100);
+    }, 150);
   };
   const handleSelectSort = (e) => {
     setIsDropBoxOpen(false);

--- a/lib/getNotices.ts
+++ b/lib/getNotices.ts
@@ -11,7 +11,8 @@ export const getNotices = async (
   sort?: Sort
 ): Promise<Notices> => {
   const keywordQuery = keyword ? `&keyword=${keyword}` : "";
-  const addressQuery = address ? `&address=${address}` : "";
+  const addressQueryArray = address?.map((add) => `&address=${add}`).join("");
+  const addressQuery = address ? addressQueryArray : "";
   const startsAtGteQuery = startsAtGte ? `&startsAtGte=${startsAtGte}` : "";
   const hourlyPayGteQuery = hourlyPayGte ? `&hourlyPayGte=${hourlyPayGte}` : "";
   const sortQuery = sort ? `&sort=${sort}` : "";


### PR DESCRIPTION
## 주요 구현 사항 ✨

- 상세필터를 적용할 때, 주소를 넘거주는 쿼리를 수정했습니다.
- 정렬 박스를 빠르게 여러번 눌렀을 때, 적용되지 않는 부분을 수정했습니다. 


## 스크린샷 🎨

-

## 구체적 구현 사항 설명 📃
- 주소를 어떻게 넘겨줘야 오류가 안생기는지 한참 고민했는데, 주소가 여러 개일 경우, &address="주소"&address="주소"형태로 넣어줘야한다는 것을 깨닫고 수정했습니다.
- 정렬 박스를 닫기 위해 setTimeout을 사용하는데 기존의 기준 시간을 100미리초에서 150미리초로 수정했습니다.

## 논의사항 🤔

-

