### PR TITLE
상세필터 오류들 수정

### DIFF
--- a/components/Notices/Notices.tsx
+++ b/components/Notices/Notices.tsx
@@ -102,7 +102,7 @@ export default function Notices({ keyword }: Props) {
         >
           <div className={cn("address")}>
             <FilterDropBoxShell.FilterTitle text="위치" />
-            <FilterDropBoxShell.AddressBox setFilter={setFilter} />
+            <FilterDropBoxShell.AddressBox filter={filter} setFilter={setFilter} />
             {filter.address?.length !== 0 && (
               <FilterDropBoxShell.SelectedAddress address={filter.address} setFilter={setFilter} />
             )}

--- a/components/Notices/filterDropBox/addressbadge/AddressBadge.module.scss
+++ b/components/Notices/filterDropBox/addressbadge/AddressBadge.module.scss
@@ -17,5 +17,12 @@
 }
 
 .closeIcon {
-  padding-bottom: 0.2rem;
+  display: block;
+
+  width: 1.6rem;
+  height: 1.6rem;
+  background: url("~/public/images/close_red.svg") no-repeat center;
+  overflow: hidden;
+  text-indent: 100%;
+  white-space: nowrap;
 }

--- a/components/Notices/filterDropBox/addressbadge/AddressBadge.tsx
+++ b/components/Notices/filterDropBox/addressbadge/AddressBadge.tsx
@@ -1,10 +1,7 @@
-import Image from "next/image";
 import { Dispatch, SetStateAction } from "react";
 import classNames from "classnames/bind";
 
 import { Filter } from "@/types/noticesType";
-
-import Close from "@/public/images/close_red.svg";
 
 import styles from "./AddressBadge.module.scss";
 
@@ -23,7 +20,7 @@ export default function AddressBadge({ text, setFilter }: Props) {
   return (
     <button className={cn("button")} value={text} onClick={(e) => handleDeleteAddress(e)}>
       {text}
-      <Image className={cn("closeIcon")} src={Close} alt="닫기" width={16} height={16} />
+      <span className={cn("closeIcon")}>선택 취소</span>
     </button>
   );
 }

--- a/components/Notices/filterDropBox/filterAddress/FilterAddress.tsx
+++ b/components/Notices/filterDropBox/filterAddress/FilterAddress.tsx
@@ -9,11 +9,16 @@ import styles from "./FilterAddress.module.scss";
 const cn = classNames.bind(styles);
 
 type Props = {
+  filter: Filter;
   setFilter: Dispatch<SetStateAction<Filter>>;
 };
 
-export default function FilterAddress({ setFilter }: Props) {
-  const handleButtonClick = (add: string) => setFilter((prev) => ({ ...prev, address: [...prev.address, add] }));
+export default function FilterAddress({ filter, setFilter }: Props) {
+  const handleButtonClick = (add: string) => {
+    if (!filter.address?.includes(add)) {
+      setFilter((prev) => ({ ...prev, address: [...prev.address, add] }));
+    }
+  };
   return (
     <div className={cn("addressWrap")}>
       <div className={cn("totalAddress")}>

--- a/components/Notices/filterDropBox/filterDropBoxShell/FilterDropBoxShell.module.scss
+++ b/components/Notices/filterDropBox/filterDropBoxShell/FilterDropBoxShell.module.scss
@@ -62,6 +62,18 @@
   color: $color-black;
 }
 
+.closeIcon {
+  display: block;
+  width: 2.4rem;
+  height: 2.4rem;
+  background: url("~/public/images/close.svg") no-repeat center;
+  overflow: hidden;
+  text-indent: 100%;
+  white-space: nowrap;
+
+  cursor: pointer;
+}
+
 .section {
   display: flex;
   flex-direction: column;

--- a/components/Notices/filterDropBox/filterDropBoxShell/FilterDropBoxShell.tsx
+++ b/components/Notices/filterDropBox/filterDropBoxShell/FilterDropBoxShell.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { Dispatch, ReactNode, SetStateAction, useEffect, useRef, useState } from "react";
 import classNames from "classnames/bind";
 
@@ -11,8 +10,6 @@ import Button from "@/components/common/button/Button";
 
 import { Filter } from "@/types/noticesType";
 import { initailFilter } from "@/lib/NoticesConstants";
-
-import Close from "@/public/images/close.svg";
 
 import styles from "./FilterDropBoxShell.module.scss";
 
@@ -31,7 +28,8 @@ export default function FilterDropBoxShell({ countValue, setFilter, handleFilter
 
   const count = countValue ? countValue.length : 0;
 
-  const handleDropBoxOpen = () => setIsDropBoxOpen((prev) => !prev);
+  const handleDropBoxToggle = () => setIsDropBoxOpen((prev) => !prev);
+  const handleDropBoxClose = () => setIsDropBoxOpen(false);
 
   const resetFilter = () => {
     setFilter(() => initailFilter);
@@ -58,12 +56,14 @@ export default function FilterDropBoxShell({ countValue, setFilter, handleFilter
 
   return (
     <div className={cn("wrap")} ref={dropboxRef}>
-      <button className={cn("openBox")} onClick={handleDropBoxOpen}>{`상세 필터 (${count})`}</button>
+      <button className={cn("openBox")} onClick={handleDropBoxToggle}>{`상세 필터 (${count})`}</button>
       {isDropBoxOpen && (
         <div className={cn("dropboxWrap", isDropBoxOpen && "opened")}>
           <header className={cn("header")}>
             <h3>상세 필터</h3>
-            <Image src={Close} alt="닫기" width={24} height={24} />
+            <span className={cn("closeIcon")} onClick={handleDropBoxClose}>
+              닫기
+            </span>
           </header>
           <section className={cn("section")}>{children}</section>
           <footer className={cn("footer")}>

--- a/components/Notices/sortDropBox/SortDropBox.module.scss
+++ b/components/Notices/sortDropBox/SortDropBox.module.scss
@@ -21,6 +21,25 @@
   background-color: $color-gray-10;
 }
 
+.icon {
+  display: block;
+
+  width: 1.6rem;
+  height: 1.6rem;
+
+  overflow: hidden;
+  text-indent: 100%;
+  white-space: nowrap;
+
+  &.closeIcon {
+    background: url("~/public/images/dropdown_close.svg") no-repeat center;
+  }
+
+  &.openIcon {
+    background: url("~/public/images/dropdown_open.svg") no-repeat center;
+  }
+}
+
 .dropdown {
   position: absolute;
   top: 3.8rem;

--- a/components/Notices/sortDropBox/SortDropBox.tsx
+++ b/components/Notices/sortDropBox/SortDropBox.tsx
@@ -1,9 +1,5 @@
-import Image from "next/image";
 import { useState } from "react";
 import classNames from "classnames/bind";
-
-import Open from "@/public/images/dropdown_open.svg";
-import Close from "@/public/images/dropdown_close.svg";
 
 import styles from "./SortDropBox.module.scss";
 
@@ -38,11 +34,7 @@ export default function SortDropBox({ list, selectedItem, handleSortButtonClick 
     <div className={cn("container")} onBlur={handleDropBoxBlur}>
       <button className={cn("defaultValue")} onClick={handleDropBoxOpen}>
         {selectedItem.name}
-        {isDropBoxOpen ? (
-          <Image src={Open} alt="닫기" width={10} height={10} />
-        ) : (
-          <Image src={Close} alt="열기" width={10} height={10} />
-        )}
+        <span className={cn("icon", isDropBoxOpen ? "closeIcon" : "openIcon")}>열기</span>
       </button>
       {isDropBoxOpen && (
         <ul className={cn("dropdown", isDropBoxOpen && "opened")}>


### PR DESCRIPTION
## 주요 구현 사항 ✨

- 상세필터에서 주소 선택 시, 같은 주소가 계속 들어가던 문제 수정
- 정렬 드롭박스의 아이콘 방향 수정
- 상세필터 드롭박스 전체 x 버튼 누르면 상세필터 닫히도록 수정
-상세필터, 정렬의 x 이미지 next.js의 이미지 태그가 아닌 css 백그라운드로 수정

## 스크린샷 🎨

-

## 구체적 구현 사항 설명 📃

- 미진님이 알려주신 x 모양과 같은 아이콘을 백그라운드 이미지로 넣는 방법을 적용했습니다.

## 논의사항 🤔

-

