### PR TITLE
Feat: 상세필터 UI 수정

### DIFF
--- a/components/Notices/filterDropBox/filterAddress/FilterAddress.module.scss
+++ b/components/Notices/filterDropBox/filterAddress/FilterAddress.module.scss
@@ -16,28 +16,30 @@
   padding: 1.6rem 2.4rem;
   overflow-y: scroll;
   grid-gap: 2rem;
+
+  &::-webkit-scrollbar {
+    width: 0.5rem;
+    height: 6.4rem;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: $color-white;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 4rem;
+    background-color: $color-gray-30;
+    &:hover {
+      background-color: $color-gray-50;
+    }
+  }
 }
 
 .address {
   font-size: 1.4rem;
   line-height: 2.2rem;
   text-align: start;
-}
-
-.totalAddress::-webkit-scrollbar {
-  width: 0.5rem;
-  height: 6.4rem;
-}
-
-.totalAddress::-webkit-scrollbar-track {
-  background-color: $color-white;
-}
-
-.totalAddress::-webkit-scrollbar-thumb {
-  border-radius: 4rem;
-  background-color: $color-gray-30;
-}
-
-.totalAddress::-webkit-scrollbar-thumb:hover {
-  background-color: $color-gray-50;
+  &:hover {
+    color: $color-gray-50;
+  }
 }

--- a/components/Notices/filterDropBox/filterAddress/FilterAddress.module.scss
+++ b/components/Notices/filterDropBox/filterAddress/FilterAddress.module.scss
@@ -1,7 +1,7 @@
 @use "@/styles/variables.scss" as *;
 
 .addressWrap {
-  width: 35rem;
+  width: 100%;
   height: 25.8rem;
   padding: 0.4rem;
   border: 1px solid $color-gray-20;

--- a/components/Notices/filterDropBox/filterDropBoxShell/FilterDropBoxShell.module.scss
+++ b/components/Notices/filterDropBox/filterDropBoxShell/FilterDropBoxShell.module.scss
@@ -27,18 +27,21 @@
 
 .dropboxWrap {
   position: absolute;
-  inset: 0;
+  top: 0;
+  left: 0;
+
+  width: 100vw;
+  height: 100vh;
 
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   align-items: flex-start;
   gap: 2.4rem;
 
-  padding: 2.4rem 2rem;
+  padding: 2.4rem 3.6rem 2.4rem 2rem;
   border: 1px solid $color-gray-20;
   border-radius: 1rem;
-
-  width: 39rem;
 
   background-color: $color-white;
 
@@ -52,7 +55,21 @@
   @include tablet {
     top: 3.8rem;
     right: 0;
+    left: -28.5rem;
+
+    padding: 2.4rem 2rem;
+
+    width: 39rem;
+    height: fit-content;
   }
+}
+
+.dropboxContextWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+
+  width: 100%;
 }
 
 .header {
@@ -88,12 +105,16 @@
 .footer {
   // 버튼 크기 조정
   display: grid;
-  grid-template-columns: 8.2rem auto;
+  grid-template-columns: 1fr 2fr;
   gap: 0.8rem;
 
-  margin-top: 1.6rem;
+  margin: 1.6rem auto;
 
   width: 100%;
+
+  @include tablet {
+    grid-template-columns: 8.2rem auto;
+  }
 }
 
 @keyframes open {

--- a/components/Notices/filterDropBox/filterDropBoxShell/FilterDropBoxShell.tsx
+++ b/components/Notices/filterDropBox/filterDropBoxShell/FilterDropBoxShell.tsx
@@ -59,13 +59,15 @@ export default function FilterDropBoxShell({ countValue, setFilter, handleFilter
       <button className={cn("openBox")} onClick={handleDropBoxToggle}>{`상세 필터 (${count})`}</button>
       {isDropBoxOpen && (
         <div className={cn("dropboxWrap", isDropBoxOpen && "opened")}>
-          <header className={cn("header")}>
-            <h3>상세 필터</h3>
-            <span className={cn("closeIcon")} onClick={handleDropBoxClose}>
-              닫기
-            </span>
-          </header>
-          <section className={cn("section")}>{children}</section>
+          <div className={cn("dropboxContextWrap")}>
+            <header className={cn("header")}>
+              <h3>상세 필터</h3>
+              <span className={cn("closeIcon")} onClick={handleDropBoxClose}>
+                닫기
+              </span>
+            </header>
+            <section className={cn("section")}>{children}</section>
+          </div>
           <footer className={cn("footer")}>
             <Button text="초기화" size="flexible" color="secondary" handleButtonClick={resetFilter} />
             <Button text="적용하기" size="flexible" color="primary" handleButtonClick={handleFilterSubmit} />

--- a/components/Notices/filterDropBox/filterTitle/FilterTitle.module.scss
+++ b/components/Notices/filterDropBox/filterTitle/FilterTitle.module.scss
@@ -1,6 +1,8 @@
 @use "@/styles/variables.scss" as *;
 
 .sectionTitle {
+  width: 100%;
+
   color: $color-black;
   line-height: 2.6rem;
 }

--- a/components/Notices/filterDropBox/hourlyPayInput/HourlyPayInput.module.scss
+++ b/components/Notices/filterDropBox/hourlyPayInput/HourlyPayInput.module.scss
@@ -4,6 +4,8 @@
   display: flex;
   align-items: center;
   gap: 1.2rem;
+
+  width: 100%;
 }
 
 .inputWrap {
@@ -16,17 +18,25 @@
   border: 1px solid $color-gray-30;
   border-radius: 0.6rem;
 
-  width: 16.9rem;
+  width: 24rem;
 
   color: $color-black;
   line-height: 2.6rem;
 
   background: $color-white;
+
+  @include tablet {
+    width: 16.9rem;
+  }
 }
 
 .input {
   border: none;
-  width: 11rem;
+  width: 18rem;
+
+  @include tablet {
+    width: 11rem;
+  }
 }
 
 .input::placeholder {


### PR DESCRIPTION
## 주요 구현 사항 ✨

- 모바일에서는 상세필터가 화면에 꽉차도록 수정했습니다.
- 상세 필터 배경 하얀색이 적용되지 않던 점을 수정했습니다.

## 스크린샷 🎨

![스크린샷 2024-02-06 오후 8 28 26](https://github.com/sprintPart3Team4/the-julge/assets/141597336/814b15e7-4eb0-4535-bc90-cb32f9819b29)
![스크린샷 2024-02-06 오후 8 28 37](https://github.com/sprintPart3Team4/the-julge/assets/141597336/2f8ccd46-be53-447f-bba9-6fc12a6c226a)


## 구체적 구현 사항 설명 📃

-

## 논의사항 🤔

- 모바일에서 상세 필터를 화면에 꽉 채울 때, 상세 필터가 아닌 이 상세 필터가 존재하는 "페이지" 자체의 스크롤바를 숨길 수 있나요? 그러니까 상세 필터가 켜져 있을 때만?
- 이제 상세 필터 ui가 완성된 것이길....ㅎㅎ