### PR TITLE
Feat: 공통/gnb-유저 타입에 따른 버튼과 로그아웃 버튼 클릭 시 해당 페이지로 이동

### DIFF
--- a/components/common/navBar/NavBar.tsx
+++ b/components/common/navBar/NavBar.tsx
@@ -28,6 +28,8 @@ export default function NavBar(/* { setKeyword, setCount, setNoticeList }: Props
 
   const { user, logout } = useAuth();
 
+  const userPage = user?.type === "employee" ? "내 프로필" : "내 가게";
+
   const LIMIT_PER_SINGLE_PAGE = 30; // 한 페이지에 보여줄 데이터의 개수
 
   const handleKeywordChange = (e: any) => {
@@ -66,8 +68,8 @@ export default function NavBar(/* { setKeyword, setCount, setNoticeList }: Props
       </div>
       {user ? (
         <div className={cn("buttons")}>
-          <Link href={"/profile"} className={cn("button")}>
-            내 프로필
+          <Link href={userPage === "내 가게" ? "/shop" : "/profile"} className={cn("button")}>
+            {userPage}
           </Link>
           <button type="button" className={cn("button")} onClick={logout}>
             로그아웃

--- a/components/common/navBar/NavBar.tsx
+++ b/components/common/navBar/NavBar.tsx
@@ -49,7 +49,6 @@ export default function NavBar(/* { setKeyword, setCount, setNoticeList }: Props
   const handleKeywordSubmit = (e: any) => {
     e.preventDefault();
     const query = `?keyword=${keyword}`;
-    // query ?
     router.push(`/search${query}`);
   };
 
@@ -71,9 +70,11 @@ export default function NavBar(/* { setKeyword, setCount, setNoticeList }: Props
           <Link href={userPage === "내 가게" ? "/shop" : "/profile"} className={cn("button")}>
             {userPage}
           </Link>
-          <button type="button" className={cn("button")} onClick={logout}>
-            로그아웃
-          </button>
+          <Link href="/">
+            <button type="button" className={cn("button")} onClick={logout}>
+              로그아웃
+            </button>
+          </Link>
           <button type="button" className={cn("button")} onClick={handleToggleNotification}>
             <Image className={cn("icon")} src={InactiveNotificationIcon} alt="알림 아이콘" width={17} height={17} />
           </button>

--- a/components/common/navBar/NavBar.tsx
+++ b/components/common/navBar/NavBar.tsx
@@ -1,11 +1,10 @@
-import React, { Dispatch, SetStateAction, useState } from "react";
+import React, { useState } from "react";
 import classNames from "classnames/bind";
 import Image from "next/image";
 import Link from "next/link";
 import Logo from "../logo/Logo";
 import NotificationList from "./notificationList/NotificationList";
 import { useAuth } from "@/contexts/AuthProvider";
-import { NoticeList } from "@/types/noticesType";
 import SearchIcon from "@/public/images/search.svg";
 import ActiveNotificationIcon from "@/public/images/notification_active.svg";
 import InactiveNotificationIcon from "@/public/images/notification_inactive.svg";
@@ -14,30 +13,16 @@ import { useRouter } from "next/router";
 
 const cn = classNames.bind(styles);
 
-// type Props = {
-//   setKeyword: Dispatch<SetStateAction<string>>;
-//   setCount: Dispatch<SetStateAction<number>>;
-//   setNoticeList: Dispatch<SetStateAction<NoticeList>>;
-// };
-
-export default function NavBar(/* { setKeyword, setCount, setNoticeList }: Props */) {
+export default function NavBar() {
   const [keyword, setKeyword] = useState("");
-  const [count, setCount] = useState(0);
-  const [noticeList, setNoticeList] = useState<NoticeList>([]);
   const [isOpen, setIsOpen] = useState(false);
 
   const { user, logout } = useAuth();
 
   const userPage = user?.type === "employee" ? "내 프로필" : "내 가게";
 
-  const LIMIT_PER_SINGLE_PAGE = 30; // 한 페이지에 보여줄 데이터의 개수
-
   const handleKeywordChange = (e: any) => {
     setKeyword(e.target.value);
-    // getNotices(0, LIMIT_PER_SINGLE_PAGE, e.target.value).then(({ count, items }) => {
-    //   setCount(count);
-    //   setNoticeList(items);
-    // });
   };
 
   const router = useRouter();


### PR DESCRIPTION
## 주요 구현 사항 ✨

- 유저 타입에 따라 어느 마이페이지로 이동할지 ui 반영 및 알맞는 페이지로 이동
- 로그아웃 버튼 클릭 시 로그아웃 + 메인페이지로 이동

## 스크린샷 🎨
- user.type === "employer" 사장님 회원일 경우 - "내 가게 클릭 시 '/shop'으로 이동
<img width="593" alt="image" src="https://github.com/sprintPart3Team4/the-julge/assets/148641571/16dbfba9-d9a8-4ba1-ab34-9207cb8d7bd8">

- user.type === "employee" 알바 회원일 경우 - "내 프로필 클릭 시 '/profile'으로 이동
<img width="695" alt="image" src="https://github.com/sprintPart3Team4/the-julge/assets/148641571/2cc126aa-3d65-48b7-9a80-943fc122b3b9">


## 구체적 구현 사항 설명 📃
- 스크린 샷 참고

## 논의사항 🤔
- 굿

