### PR TITLE
fix : 알바님/신청내역 시간, 시급, 색상 수정

### DIFF
--- a/components/user/userApplication/UserApplication.tsx
+++ b/components/user/userApplication/UserApplication.tsx
@@ -10,7 +10,7 @@ type Props = {
   applicationId: string;
   name?: string;
   startsAt?: string;
-  hourlyPay?: number;
+  hourlyPay?: string;
   status: "pending" | "accepted" | "rejected" | "canceled";
 };
 

--- a/components/user/userApplication/UserApplications.module.scss
+++ b/components/user/userApplication/UserApplications.module.scss
@@ -54,7 +54,7 @@
   line-height: 2.2rem;
 
   text-align: start;
-
+  background-color: $color-white;
   &.name {
     background-color: $color-white;
   }
@@ -71,6 +71,12 @@
   left: 0;
   z-index: 1;
 }
+
+// .status {
+//   position: sticky;
+//   right: 0;
+//   z-index: 1;
+// }
 
 .bioLineUp {
   display: -webkit-box;

--- a/components/user/userApplication/UserApplications.tsx
+++ b/components/user/userApplication/UserApplications.tsx
@@ -2,10 +2,7 @@ import classNames from "classnames/bind";
 import UserApplication from "./UserApplication";
 import styles from "./UserApplications.module.scss";
 import { UserApplicationList } from "@/types/apiTypes";
-import { useState, useEffect } from "react";
-import instance from "@/lib/axiosInstance";
-import getCookies from "@/lib/getCookies";
-import { useAuth } from "@/contexts/AuthProvider";
+import { getFullDate } from "@/lib/getFullDate";
 
 const cn = classNames.bind(styles);
 
@@ -52,7 +49,7 @@ export default function UserApplications({ applyList }: Props) {
                     item: { name },
                   },
                   notice: {
-                    item: { hourlyPay, startsAt },
+                    item: { hourlyPay, startsAt, workhour },
                   },
                 },
               }) => (
@@ -61,8 +58,8 @@ export default function UserApplications({ applyList }: Props) {
                   applicationId={id}
                   status={status}
                   name={name}
-                  startsAt={startsAt}
-                  hourlyPay={hourlyPay}
+                  startsAt={getFullDate(startsAt, workhour)}
+                  hourlyPay={hourlyPay.toLocaleString()}
                 />
               )
             )}

--- a/components/user/userPageLayout/UserPageLayout.module.scss
+++ b/components/user/userPageLayout/UserPageLayout.module.scss
@@ -50,6 +50,7 @@
 
   max-width: 96.4rem;
   width: calc(100% - $mobile-safezone * 2);
+  background-color: $color-white;
 }
 
 .pagenation {


### PR DESCRIPTION
## 주요 구현 사항 ✨

- 신청내역에 일자, 시급(원단위), 테이블 색상 수정하였습니다.

## 스크린샷 🎨

- ![image](https://github.com/sprintPart3Team4/the-julge/assets/84887815/85d10468-bfca-41bb-84a1-6818f82a3f1b)

## 구체적 구현 사항 설명 📃

- 일자는 0기분들은 ex (4시간)이 없었는데.. 피그마에는 있어서 피그마 기준으로 수정하였어요!
- 시급은 지선님이 쓰셨던 코드 참고해서 3자리 수마다 ,(쉼표)가 나오는 코드로 수정하였습니다.
- 이외 테이블바디와 페이지네이션 부분 색상 추가하였습니다.

## 논의사항 🤔

- 모바일과 테블릿 환경에서 상태 부분이 안나오는데 더줄게 피그마 처럼 상태가 나오는게 좋을까요..?
![image](https://github.com/sprintPart3Team4/the-julge/assets/84887815/bbff7e06-2f2a-431e-9441-729831660b9c)
횡스크롤이 되니까.. 굳이 안나와도 될 것 같기도 합니다.

