### PR TITLE
Feat: 공고 카드 - 상황에 맞는 링크 이동

### DIFF
--- a/components/common/input/Input.tsx
+++ b/components/common/input/Input.tsx
@@ -16,7 +16,7 @@ export interface InputProps {
   floatingText?: string;
   placeholder?: string;
   value?: string;
-
+}
 
 export default function Input({ label, title, input, value, onChange, floatingText, placeholder }: InputProps) {
   return (

--- a/components/noticeList/noticeCard/noticeCard.tsx
+++ b/components/noticeList/noticeCard/noticeCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import classNames from "classnames/bind";
@@ -7,51 +7,40 @@ import LocationIcon from "@/public/images/location.svg";
 import GreyLocationIcon from "@/public/images/location_grey.svg";
 import ClockIcon from "@/public/images/clock.svg";
 import GreyClockIcon from "@/public/images/clock_grey.svg";
-import { useAuth } from "@/contexts/AuthProvider";
 import { getFullDate } from "@/lib/getFullDate";
-import { NoticeItem, Shop } from "@/types/noticesType";
-import instance from "@/lib/axiosInstance";
 import styles from "./NoticeCard.module.scss";
 
 const cn = classNames.bind(styles);
 
 type Props = {
-  id: string;
+  noticeId: string;
   startsAt: string;
   workhour: number;
   hourlyPay: number;
   closed?: boolean;
-  shop: {
-    item: Shop;
-    href: string;
-  };
+  noticeShopId: string | undefined;
+  myShopId?: string;
+  imageUrl: string;
+  name: string;
+  address1: string;
+  originalHourlyPay: number;
 };
 
-export default function NoticeCard({ id, startsAt, workhour, hourlyPay, closed = false, shop }: Props) {
-  const [href, setHref] = useState<string>("");
-  const { user } = useAuth();
-  const noticeId = id;
-  const shopId = shop.item.id;
-  const query = `?s=${shopId}&u=${noticeId}`;
-
-  const getNoticeList = async (): Promise<NoticeItem[]> => {
-    const res = await instance.get(`shops/${shopId}/notices`);
-    return res.data.items;
-  };
-
-  useEffect(() => {
-    if (!user) {
-      setHref(`detail${query}`); // 로그인 하지 않은 유저
-    } else if (shopId) {
-      getNoticeList().then((res) => {
-        if (res.some((notice) => notice.item.id === noticeId))
-          setHref(`shop/${noticeId}`); // 가게 등록을 한 사장님 자신의 공고일 때
-        else setHref(`detail${query}`); // 가게 등록을 했지만 자신의 공고가 아닐 때
-      });
-    } else {
-      setHref(`detail${query}`);
-    } // 일반 유저 or 가게 등록을 하지 않은 사장님
-  }, []);
+export default function NoticeCard({
+  noticeId,
+  startsAt,
+  workhour,
+  hourlyPay,
+  closed,
+  noticeShopId,
+  myShopId,
+  imageUrl,
+  name,
+  address1,
+  originalHourlyPay,
+}: Props) {
+  const query = `?s=${noticeShopId}&u=${noticeId}`;
+  const href = noticeShopId === myShopId ? `shop/${noticeId}` : `detail${query}`;
 
   return (
     <Link href={href}>
@@ -59,18 +48,18 @@ export default function NoticeCard({ id, startsAt, workhour, hourlyPay, closed =
         <div className={cn("imageWidth")}>
           <div className={cn("imageHeight")}>
             {closed && <div className={cn("imgOverlay")}>마감 완료</div>}
-            <Image className={cn("image")} src={shop.item.imageUrl} alt="가게 이미지" fill />
+            <Image className={cn("image")} src={imageUrl} alt="가게 이미지" fill />
           </div>
         </div>
         <div className={cn("contents")}>
-          <span className={cn("shopName")}>{shop.item.name}</span>
+          <span className={cn("shopName")}>{name}</span>
           <div className={cn("time")}>
             <Image src={closed ? GreyClockIcon : ClockIcon} alt="시계 아이콘" width={20} height={20} />
             <span>{getFullDate(startsAt, workhour)}</span>
           </div>
           <div className={cn("location")}>
             <Image src={closed ? GreyLocationIcon : LocationIcon} alt="장소 아이콘" width={20} height={20} />
-            <span>{shop.item.address1}</span>
+            <span>{address1}</span>
           </div>
           <div className={cn("pays")}>
             <span className={cn("pay")}>{hourlyPay.toLocaleString("ko-KR")}원</span>
@@ -78,7 +67,7 @@ export default function NoticeCard({ id, startsAt, workhour, hourlyPay, closed =
               isListedCard
               closed={closed}
               hourlyPay={hourlyPay}
-              originalHourlyPay={shop.item.originalHourlyPay || 0}
+              originalHourlyPay={originalHourlyPay || 0}
             />
           </div>
         </div>

--- a/components/noticeList/noticeCardList/NoticeCardList.tsx
+++ b/components/noticeList/noticeCardList/NoticeCardList.tsx
@@ -2,6 +2,9 @@ import classNames from "classnames/bind";
 import { NoticeList } from "@/types/noticesType";
 import styles from "./NoticeCardList.module.scss";
 import NoticeCard from "../noticeCard/noticeCard";
+import getCookies from "@/lib/getCookies";
+import instance from "@/lib/axiosInstance";
+import { useEffect, useState } from "react";
 
 const cn = classNames.bind(styles);
 
@@ -10,19 +13,40 @@ type Props = {
 };
 
 export default function NoticeCardList({ noticeList }: Props) {
+  const { shopId: myShopId } = getCookies();
+
   return (
     <div className={cn("wrap")}>
-      {noticeList?.map(({ item: { id, startsAt, workhour, hourlyPay, closed, shop } }) => {
-        const noticeCardProps = {
-          id,
-          startsAt,
-          workhour,
-          hourlyPay,
-          closed,
-          shop,
-        };
-        return <NoticeCard key={id} {...noticeCardProps} />;
-      })}
+      {noticeList?.map(
+        ({
+          item: {
+            id: noticeId,
+            startsAt,
+            workhour,
+            hourlyPay,
+            closed,
+            shop: {
+              item: { id: noticeShopId, imageUrl, name, address1, originalHourlyPay },
+            },
+          },
+        }) => {
+          const noticeCardProps = {
+            noticeId,
+            startsAt,
+            workhour,
+            hourlyPay,
+            closed,
+            noticeShopId,
+            myShopId,
+            imageUrl,
+            name,
+            address1,
+            originalHourlyPay,
+          };
+
+          return <NoticeCard key={noticeId} {...noticeCardProps} />;
+        }
+      )}
     </div>
   );
 }

--- a/components/shop/myShopProfile/MyShopProfile.tsx
+++ b/components/shop/myShopProfile/MyShopProfile.tsx
@@ -12,11 +12,7 @@ type Prop = {
   toggleNoticeOpen: () => void;
 };
 
-export default function MyShopProfile({
-  toggleInfoOpen,
-  toggleNoticeOpen,
-}: Prop) {
-        
+export default function MyShopProfile({ toggleInfoOpen, toggleNoticeOpen }: Prop) {
   const { shop } = useAuth();
 
   if (!shop) return;
@@ -34,12 +30,7 @@ export default function MyShopProfile({
           <span className={cn("category")}>{category}</span>
           <span className={cn("name")}>{name}</span>
           <div className={cn("location")}>
-            <Image
-              src={LocationIcon}
-              alt="위치 아이콘"
-              width={20}
-              height={20}
-            />
+            <Image src={LocationIcon} alt="위치 아이콘" width={20} height={20} />
             <span>{address1}</span>
           </div>
           <span className={cn("description")}>
@@ -52,18 +43,8 @@ export default function MyShopProfile({
           </span>
         </div>
         <div className={cn("buttons")}>
-          <Button
-            text="편집하기"
-            size="flexible"
-            color="secondary"
-            handleButtonClick={toggleInfoOpen}
-          ></Button>
-          <Button
-            text="공고 등록하기"
-            size="flexible"
-            color="primary"
-            handleButtonClick={toggleNoticeOpen}
-          ></Button>
+          <Button text="편집하기" size="flexible" color="secondary" handleButtonClick={toggleInfoOpen}></Button>
+          <Button text="공고 등록하기" size="flexible" color="primary" handleButtonClick={toggleNoticeOpen}></Button>
         </div>
       </div>
     </div>

--- a/components/shop/noticeCardList/NoticeCardList.tsx
+++ b/components/shop/noticeCardList/NoticeCardList.tsx
@@ -53,7 +53,6 @@ export default function NoticeCardList() {
       if (observer.current) observer.current.disconnect();
       observer.current = new IntersectionObserver((entries) => {
         if (entries[0].isIntersecting && hasNext) {
-          console.log(offset);
           handleLoad({ offset, limit: LIMIT });
         }
       });

--- a/components/shop/noticeCardList/NoticeCardList.tsx
+++ b/components/shop/noticeCardList/NoticeCardList.tsx
@@ -35,6 +35,7 @@ async function getNoticeList({ offset = 0, limit = LIMIT }: Props): Promise<Noti
   const { shopId } = getCookies();
   const query = `offset=${offset}&limit=${limit}`;
   const res = await instance.get<NoticeListResponse>(`shops/${shopId}/notices?${query}`);
+  // console.log(res.data.count);
   return res.data;
 }
 
@@ -52,19 +53,20 @@ export default function NoticeCardList() {
       if (observer.current) observer.current.disconnect();
       observer.current = new IntersectionObserver((entries) => {
         if (entries[0].isIntersecting && hasNext) {
+          console.log(offset);
           handleLoad({ offset, limit: LIMIT });
         }
       });
       if (node) observer.current.observe(node);
     },
-    [isLoading, hasNext]
+    [isLoading, hasNext, offset]
   );
 
   const handleLoad = async (options: Props) => {
     const { items, hasNext } = await getNoticeList(options);
     try {
       setCardList((prevList) => [...prevList, ...items]);
-      setOffset(options.offset + items.length);
+      setOffset((prev) => prev + LIMIT);
       setHasNext(hasNext);
       setIsLoading(false);
     } catch (error) {
@@ -74,7 +76,7 @@ export default function NoticeCardList() {
 
   useEffect(() => {
     handleLoad({ offset, limit: LIMIT });
-  });
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 사장님 유저가 공고 리스트 중 자신의 가게의 공고 카드를 클릭 했을 때 `detail`이 아닌 `shop/[noticeId]`으로 이동
- 그 외의 경우에는 공고 카드 클릭 시 `detail` 페이지로 이동
  - query 값으로는 ?s={shopId}&u={noticeId} 형식으로 전달
- `/shop`페이지 무한 스크롤 문제 해결

## 스크린샷 🎨
- 사장님 유저가 자신이 올린 공고를 클릭했을 때
![image](https://github.com/sprintPart3Team4/the-julge/assets/148641571/2dd06359-a94e-4fa8-8559-99dc9d807ad9)

- 일반적인 경우
![image](https://github.com/sprintPart3Team4/the-julge/assets/148641571/5a6f3752-b4cb-4e38-b7c4-085e1756c709)
-> 경로만 참고해주세요. 이 페이지는 아직 미진님 수정사항 합쳐지기 전이라서 404네요.

## 구체적 구현 사항 설명 📃
-

## 논의사항 🤔
- 진짜 안 풀리는 문제들이었는데 오늘 멘토링 때 답을 얻어서 드디어 해결했습니다!!!!
- 특히 상황에 맞게 href 넘겨주는 문제는 생각보다 너무 간단하게 해결되었습다.
    - 상위 컴포넌트에서 사장님의 shopId를 프롭으로 전달해주고
    - 자식 컴포넌트에서는 그 shopId가 공고의 shopId와 일치하는지 확인하여 경로 결정
- 근데 넘겨주는 프롭의 수가 되게 ... 많습니다 ㅋㅋ 좀 지저분해보이긴 하네요

