### PR TITLE
Fix: 공통/캐러셀 API GET 요청 시, 무한렌더링 오류 수정

### DIFF
--- a/components/common/customNotice/CustomNotice.module.scss
+++ b/components/common/customNotice/CustomNotice.module.scss
@@ -25,6 +25,10 @@
       width: max-content;
       animation: autoPlay 500s linear infinite;
 
+      &.active {
+        animation: autoplay 0s linear infinite;
+      }
+
       @keyframes autoPlay {
         0% {
           transform: translateX(0);

--- a/components/common/customNotice/CustomNotice.tsx
+++ b/components/common/customNotice/CustomNotice.tsx
@@ -11,8 +11,11 @@ const cn = classNames.bind(styles);
 interface Item {
   id: string;
   hourlyPay: number;
+  startsAt: string;
   workhour: number;
-  descriptio: string;
+  description: string;
+  closed: boolean;
+  shop: any;
 }
 
 interface Cookie {
@@ -22,15 +25,17 @@ interface Cookie {
 
 export default function CustomNotice() {
   const [customList, setCustomList] = useState<Array<Item>>([]);
-  const [cookie, setCookie] = useState<Cookie>({shopId: undefined, userId: undefined});
+  const [cookie, setCookie] = useState<Cookie>({ shopId: undefined, userId: undefined });
+  const speed = customList.length < 4 ? "active" : "";
 
   useEffect(() => {
     const { shopId, userId } = getCookies();
-    setCookie((prevState: Cookie) => ({...prevState, shopId: shopId, userId: userId}))
+    setCookie((prevState: Cookie) => ({ ...prevState, shopId: shopId, userId: userId }));
 
     async function showCarousel() {
       if (userId && !shopId) {
-        await useDobbyCustomList(setCustomList, userId);
+        const data = await useDobbyCustomList(setCustomList, userId);
+        data.length === 0 ? useNotDobbyCustomList(setCustomList) : {};
       } else {
         await useNotDobbyCustomList(setCustomList);
       }
@@ -43,7 +48,7 @@ export default function CustomNotice() {
     <div className={cn("wrap")}>
       <div className={cn("contentWrap")}>
         <p className={cn("title")}>맞춤 공고</p>
-        <div className={cn("noticeCardList")}>
+        <div className={cn("noticeCardList", { active: speed })}>
           {customList.map((card: any, index: number) => {
             return (
               <div className={cn("noticeCardBox")} key={index}>

--- a/components/common/customNotice/useDobbyCustomList.ts
+++ b/components/common/customNotice/useDobbyCustomList.ts
@@ -8,7 +8,8 @@ export default async function useDobbyCustomList(setCustomList: (arg: Array<any>
   const userAddress = userData.data.item.address;
   const res = (await instance.get(`notices`)).data;
   const customItems = res.items.filter(
-    (i: any) => i.item.shop.item.address1 === userAddress && new Date(i.item.startsAt) > currentDate && i.item.closed === false
+    (i: any) =>
+      i.item.shop.item.address1 === userAddress && new Date(i.item.startsAt) > currentDate && i.item.closed === false
   );
   let customList = [...customItems];
 
@@ -17,12 +18,15 @@ export default async function useDobbyCustomList(setCustomList: (arg: Array<any>
 
   if (res.hasNext) {
     recursion(url);
+  } else {
+    setCustomList(customList);
   }
 
   async function recursion(url: string) {
     const res = (await instance.get(`notices${url}`)).data;
     const customItems = res.items.filter(
-      (i: any) => i.item.shop.item.address1 === userAddress && new Date(i.item.startsAt) > currentDate && i.item.closed === false
+      (i: any) =>
+        i.item.shop.item.address1 === userAddress && new Date(i.item.startsAt) > currentDate && i.item.closed === false
     );
     customList.push(...customItems);
     if (res.hasNext) {
@@ -33,4 +37,6 @@ export default async function useDobbyCustomList(setCustomList: (arg: Array<any>
       setCustomList(customList);
     }
   }
+
+  return customList;
 }

--- a/components/common/customNotice/useDobbyCustomList.ts
+++ b/components/common/customNotice/useDobbyCustomList.ts
@@ -2,9 +2,14 @@ import instance from "@/lib/axiosInstance";
 
 export default async function useDobbyCustomList(setCustomList: (arg: Array<any>) => void, userId: string) {
   const userData = await instance.get(`users/${userId}`);
+
+  const currentDate = new Date();
+
   const userAddress = userData.data.item.address;
   const res = (await instance.get(`notices`)).data;
-  const customItems = res.items.filter((i: any) => i.item.shop.item.address1 === userAddress);
+  const customItems = res.items.filter(
+    (i: any) => i.item.shop.item.address1 === userAddress && new Date(i.item.startsAt) > currentDate && i.item.closed === false
+  );
   let customList = [...customItems];
 
   const nextUrl = res.links[2].href;
@@ -16,7 +21,9 @@ export default async function useDobbyCustomList(setCustomList: (arg: Array<any>
 
   async function recursion(url: string) {
     const res = (await instance.get(`notices${url}`)).data;
-    const customItems = res.items.filter((i: any) => i.item.shop.item.address1 === userAddress);
+    const customItems = res.items.filter(
+      (i: any) => i.item.shop.item.address1 === userAddress && new Date(i.item.startsAt) > currentDate && i.item.closed === false
+    );
     customList.push(...customItems);
     if (res.hasNext) {
       const nextUrl = res.links[2].href;

--- a/components/common/customNotice/useNotDobbyCustomList.ts
+++ b/components/common/customNotice/useNotDobbyCustomList.ts
@@ -2,7 +2,11 @@ import instance from "@/lib/axiosInstance";
 
 export default async function useNotDobbyCustomList(setCustomList: (arg: Array<any>) => void) {
   const res = (await instance.get(`notices`)).data;
-  let customList = [...res.items];
+  const currentDate = new Date();
+  const customItems = res.items.filter(
+    (i: any) => new Date(i.item.startsAt) > currentDate && i.item.closed === false
+  );
+  let customList = [...customItems];
 
   const nextUrl = res.links[2].href;
   const url = nextUrl.substring(nextUrl.indexOf("?"));
@@ -13,7 +17,10 @@ export default async function useNotDobbyCustomList(setCustomList: (arg: Array<a
 
   async function recursion(url: string) {
     const res = (await instance.get(`notices${url}`)).data;
-    customList.push(...res.items);
+    const customItems = res.items.filter(
+      (i: any) => new Date(i.item.startsAt) > currentDate && i.item.closed === false
+    );
+    customList.push(...customItems);
     if (res.hasNext) {
       const nextUrl = res.links[2].href;
       const nextUrlParams = nextUrl.substring(nextUrl.indexOf("?"));


### PR DESCRIPTION
## 주요 구현 사항 ✨

-

## 스크린샷 🎨

![image](https://github.com/sprintPart3Team4/the-julge/assets/145626840/83dd5775-14c3-4e90-9be8-45f04ea5686a)


## 구체적 구현 사항 설명 📃

- 접속한 유저가 알바님일시, useDobbyCunstomList를 실행하고, 만약 반환되는 요소가 0개면, useNotDobbyCustomList를 사용해 전체공고를 띄우는 과정에서 무한렌더링 발생.
- 커스텀 훅에서 변경한 state값을 비교하지 않고, await으로 반환받은 값으로 직접 받고 비교하였음

## 논의사항 🤔

-

